### PR TITLE
fix: replace float with double

### DIFF
--- a/engine/clients/milvus/configure.py
+++ b/engine/clients/milvus/configure.py
@@ -26,7 +26,7 @@ class MilvusConfigurator(BaseConfigurator):
         "int": DataType.INT64,
         "keyword": DataType.VARCHAR,
         "text": DataType.VARCHAR,
-        "float": DataType.FLOAT,
+        "float": DataType.DOUBLE,
         "geo": DataType.UNKNOWN,
     }
 


### PR DESCRIPTION
I tried to launch `milvus` on `random-range-2048-angular-filters` dataset and it failed on the uploading stage with the following traceback:

```
raise DataNotMatchException(message=f"The data type of field {y.name} doesn't match, expected: {y.dtype.name}, got {x.dtype.name}")
AttributeError: 'int' object has no attribute 'name'
```

Once I changed `float` to `double` the errors disappeared and milvus was able to finish successfully.
