### PR TITLE
Elasticsearch - Disable source and refresh

### DIFF
--- a/engine/clients/elasticsearch/configure.py
+++ b/engine/clients/elasticsearch/configure.py
@@ -55,7 +55,19 @@ class ElasticConfigurator(BaseConfigurator):
 
         self.client.indices.create(
             index=ELASTIC_INDEX,
+            settings={
+                "index": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 0,
+                    "refresh_interval": -1,
+                }
+            },
             mappings={
+                "_source": {
+                    "excludes": [
+                        "vector"
+                    ]
+                },
                 "properties": {
                     "vector": {
                         "type": "dense_vector",

--- a/engine/clients/elasticsearch/configure.py
+++ b/engine/clients/elasticsearch/configure.py
@@ -63,11 +63,7 @@ class ElasticConfigurator(BaseConfigurator):
                 }
             },
             mappings={
-                "_source": {
-                    "excludes": [
-                        "vector"
-                    ]
-                },
+                "_source": {"excludes": ["vector"]},
                 "properties": {
                     "vector": {
                         "type": "dense_vector",
@@ -84,7 +80,7 @@ class ElasticConfigurator(BaseConfigurator):
                         },
                     },
                     **self._prepare_fields_config(dataset),
-                }
+                },
             },
         )
 

--- a/engine/clients/elasticsearch/upload.py
+++ b/engine/clients/elasticsearch/upload.py
@@ -65,5 +65,5 @@ class ElasticUploader(BaseUploader):
 
     @classmethod
     def post_upload(cls, _distance):
-        cls.client.indices.forcemerge(index=ELASTIC_INDEX, wait_for_completion=True)
+        cls.client.indices.forcemerge(index=ELASTIC_INDEX, wait_for_completion=True, max_num_segments=1)
         return {}

--- a/engine/clients/elasticsearch/upload.py
+++ b/engine/clients/elasticsearch/upload.py
@@ -65,5 +65,7 @@ class ElasticUploader(BaseUploader):
 
     @classmethod
     def post_upload(cls, _distance):
-        cls.client.indices.forcemerge(index=ELASTIC_INDEX, wait_for_completion=True, max_num_segments=1)
+        cls.client.indices.forcemerge(
+            index=ELASTIC_INDEX, wait_for_completion=True, max_num_segments=1
+        )
         return {}

--- a/engine/servers/elasticsearch-single-node/docker-compose.yaml
+++ b/engine/servers/elasticsearch-single-node/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.6.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0
     environment:
       ELASTIC_PASSWORD: "passwd"
       KIBANA_PASSWORD: "passwd"


### PR DESCRIPTION
- set refresh_interval to -1 to speed up indexing
https://www.elastic.co/guide/en/elasticsearch/reference/8.7/tune-for-indexing-speed.html#_unset_or_increase_the_refresh_interval

- exclude vector from source
https://www.elastic.co/guide/en/elasticsearch/reference/8.7/tune-for-disk-usage.html#disable-source