### PR TITLE
fix milvus execution_params()

### DIFF
--- a/engine/clients/milvus/configure.py
+++ b/engine/clients/milvus/configure.py
@@ -81,4 +81,4 @@ class MilvusConfigurator(BaseConfigurator):
             index.drop()
 
     def execution_params(self, distance, vector_size):
-        return {"normalize": distance == Distance.COSINE}
+        return {"normalize": distance == Distance.COSINE or distance == Distance.DOT}


### PR DESCRIPTION
Milvus does not support cosine. Cosine is equal to IP of normalized vectors, Distance.COSINE=Distance.DOT="IP", 

so not only normalize=True when distance is Distance.COSINE, but also distance is Distance.DOT.