### PR TITLE
fix: Preserve modified time on scp and use it to sort files

### DIFF
--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -33,9 +33,9 @@ bash -x "${SCRIPT_PATH}/run_remote_benchmark.sh"
 ./mc cp results/* qdrant/vector-search-engines-benchmark/results/ci/qdrant/
 
 # Upload to postgres
-
-export SEARCH_RESULTS_FILE=$(ls -ct results/*-search-*.json | head -n 1)
-export UPLOAD_RESULTS_FILE=$(ls -ct results/*-upload-*.json | head -n 1)
-export MEMORY_USAGE_FILE=$(ls -ct results/memory-usage-*.txt | head -n 1)
+# -t sorts by modification time
+export SEARCH_RESULTS_FILE=$(ls -t results/*-search-*.json | head -n 1)
+export UPLOAD_RESULTS_FILE=$(ls -t results/*-upload-*.json | head -n 1)
+export MEMORY_USAGE_FILE=$(ls -t results/memory-usage-*.txt | head -n 1)
 
 bash -x "${SCRIPT_PATH}/upload_results_postgres.sh"

--- a/tools/run_client_script.sh
+++ b/tools/run_client_script.sh
@@ -25,4 +25,5 @@ RUN_EXPERIMENT="ENGINE_NAME=${ENGINE_NAME} DATASETS=${DATASETS} PRIVATE_IP_OF_TH
 
 ssh -tt "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "${RUN_EXPERIMENT}"
 
-scp -r "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}:~/results" "./results"
+# -p preseves modification time, access time, and modes (but not change time)
+scp -rp "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}:~/results" "./results"


### PR DESCRIPTION
Preserve modified time on scp and use it to sort files