### PR TITLE
fix: CI benchmarks should run even on existing results

### DIFF
--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -28,11 +28,11 @@ docker run \
   -it \
   -v "$HOME/results:/code/results" \
   qdrant/vector-db-benchmark:latest \
-  python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --skip-search
+  python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search
 
 docker run \
   --rm \
   -it \
   -v "$HOME/results:/code/results" \
   qdrant/vector-db-benchmark:latest \
-  python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --skip-upload
+  python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload


### PR DESCRIPTION
Shouldn't skip benchmarks on existing results in case of CI benchmarks.