### PR TITLE
fix: Reuse of Qdrant process pool should work

### DIFF
--- a/engine/clients/qdrant/search.py
+++ b/engine/clients/qdrant/search.py
@@ -1,4 +1,5 @@
 import multiprocessing as mp
+import os
 from typing import List, Tuple
 
 import httpx
@@ -17,6 +18,8 @@ class QdrantSearcher(BaseSearcher):
 
     @classmethod
     def init_client(cls, host, distance, connection_params: dict, search_params: dict):
+        os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "true"
+        os.environ["GRPC_POLL_STRATEGY"] = "epoll,poll"
         cls.client: QdrantClient = QdrantClient(
             host,
             prefer_grpc=True,

--- a/engine/clients/qdrant/upload.py
+++ b/engine/clients/qdrant/upload.py
@@ -1,3 +1,4 @@
+import os
 import time
 from typing import List, Optional
 
@@ -14,6 +15,8 @@ class QdrantUploader(BaseUploader):
 
     @classmethod
     def init_client(cls, host, distance, connection_params, upload_params):
+        os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "true"
+        os.environ["GRPC_POLL_STRATEGY"] = "epoll,poll"
         cls.client = QdrantClient(host=host, prefer_grpc=True, **connection_params)
         cls.upload_params = upload_params
 


### PR DESCRIPTION
This can be validated by running this config:
```json
{
    "name": "qdrant-parallel-error",
    "engine": "qdrant",
    "connection_params": { "timeout": 30 },
    "collection_params": {
      "optimizers_config": { "memmap_threshold": 10000000 }
    },
    "search_params": [
      { "parallel": 16, "search_params": { "hnsw_ef": 128 } },
      { "parallel": 32, "search_params": { "hnsw_ef": 128 } },
      { "parallel": 64, "search_params": { "hnsw_ef": 128 } },
      { "parallel": 100, "search_params": { "hnsw_ef": 128 } }
    ],
    "upload_params": { "parallel": 16, "batch_size": 1024 }
}
```

Previously it used to throw:
```bash
  File "/home/user/projects/qdrant/vector-db-benchmark/engine/base_client/client.py", line 113, in run_experiment
    search_stats = searcher.search_all(

  File "/home/user/projects/qdrant/vector-db-benchmark/engine/base_client/search.py", line 96, in search_all
    zip(*pool.imap_unordered(search_one, iterable=tqdm.tqdm(queries)))

  File "/usr/lib/python3.9/multiprocessing/pool.py", line 870, in next
    raise value

multiprocessing.pool.MaybeEncodingError: Error sending result: '<multiprocessing.pool.ExceptionWithTraceback object at 0x7fd403d3b4c0>'. Reason: 'TypeError("cannot pickle '_thread.RLock' object")'
```

I ran it 3 times and it failed every time but now it doesn't. The [fix](https://github.com/qdrant/vector-db-benchmark/pull/81) suggested by @qbx2 to solve the process leak also solves this. 

This doesn't impact numbers in the CI benchmarks and makes the benchmarking process smoother.