### PR TITLE
feat: Mount qdrant volume for single node docker setup

### DIFF
--- a/engine/servers/qdrant-limit-ram/docker-compose.yaml
+++ b/engine/servers/qdrant-limit-ram/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
   qdrant_bench:
     image: qdrant/qdrant:v1.7.3
     network_mode: host
+    volumes:
+      - ./storage:/qdrant/storage
     logging:
       driver: "json-file"
       options:

--- a/engine/servers/qdrant-single-node/docker-compose.yaml
+++ b/engine/servers/qdrant-single-node/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
   qdrant_bench:
     image: qdrant/qdrant:v1.7.3
     network_mode: host
+    volumes:
+      - ./storage:/qdrant/storage
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Make it easier to access Qdrant storage volume. We are already doing this for billion scale docker compose setup. 