### PR TITLE
fix: Use pgvector config properly

### DIFF
--- a/experiments/configurations/pgvector-single-node.json
+++ b/experiments/configurations/pgvector-single-node.json
@@ -39,7 +39,7 @@
         "upload_params": { "parallel": 16 }
     },
     {
-        "name": "qdrant-m-32-ef-128",
+        "name": "pgvector-m-32-ef-128",
         "engine": "qdrant",
         "connection_params": {},
         "collection_params": {
@@ -52,7 +52,7 @@
         "upload_params": { "parallel": 16 }
     },
     {
-        "name": "qdrant-m-32-ef-256",
+        "name": "pgvector-m-32-ef-256",
         "engine": "qdrant",
         "connection_params": {},
         "collection_params": {
@@ -65,7 +65,7 @@
         "upload_params": { "parallel": 16 }
     },
     {
-        "name": "qdrant-m-32-ef-512",
+        "name": "pgvector-m-32-ef-512",
         "engine": "qdrant",
         "connection_params": {},
         "collection_params": {
@@ -78,7 +78,7 @@
         "upload_params": { "parallel": 16 }
     },
     {
-        "name": "qdrant-m-64-ef-256",
+        "name": "pgvector-m-64-ef-256",
         "engine": "qdrant",
         "connection_params": {},
         "collection_params": {
@@ -91,7 +91,7 @@
         "upload_params": { "parallel": 16 }
     },
     {
-        "name": "qdrant-m-64-ef-512",
+        "name": "pgvector-m-64-ef-512",
         "engine": "qdrant",
         "connection_params": {},
         "collection_params": {

--- a/experiments/configurations/pgvector-single-node.json
+++ b/experiments/configurations/pgvector-single-node.json
@@ -40,7 +40,7 @@
     },
     {
         "name": "pgvector-m-32-ef-128",
-        "engine": "qdrant",
+        "engine": "pgvector",
         "connection_params": {},
         "collection_params": {
           "hnsw_config": { "m": 32, "ef_construct": 128 }
@@ -53,7 +53,7 @@
     },
     {
         "name": "pgvector-m-32-ef-256",
-        "engine": "qdrant",
+        "engine": "pgvector",
         "connection_params": {},
         "collection_params": {
           "hnsw_config": { "m": 32, "ef_construct": 256 }
@@ -66,7 +66,7 @@
     },
     {
         "name": "pgvector-m-32-ef-512",
-        "engine": "qdrant",
+        "engine": "pgvector",
         "connection_params": {},
         "collection_params": {
           "hnsw_config": { "m": 32, "ef_construct": 512 }
@@ -79,7 +79,7 @@
     },
     {
         "name": "pgvector-m-64-ef-256",
-        "engine": "qdrant",
+        "engine": "pgvector",
         "connection_params": {},
         "collection_params": {
           "hnsw_config": { "m": 64, "ef_construct": 256 }
@@ -92,7 +92,7 @@
     },
     {
         "name": "pgvector-m-64-ef-512",
-        "engine": "qdrant",
+        "engine": "pgvector",
         "connection_params": {},
         "collection_params": {
           "hnsw_config": { "m": 64, "ef_construct": 512 }


### PR DESCRIPTION
Most of pgvector configs were named as qdrant