### PR TITLE
fix: Use get instead of pop to avoid unexpected behaviour with multiple client/dataset runs

### DIFF
--- a/engine/base_client/search.py
+++ b/engine/base_client/search.py
@@ -60,8 +60,8 @@ class BaseSearcher:
         distance,
         queries: Iterable[Query],
     ):
-        parallel = self.search_params.pop("parallel", 1)
-        top = self.search_params.pop("top", None)
+        parallel = self.search_params.get("parallel", 1)
+        top = self.search_params.get("top", None)
 
         # setup_search may require initialized client
         self.init_client(

--- a/engine/base_client/upload.py
+++ b/engine/base_client/upload.py
@@ -31,8 +31,8 @@ class BaseUploader:
     ) -> dict:
         latencies = []
         start = time.perf_counter()
-        parallel = self.upload_params.pop("parallel", 1)
-        batch_size = self.upload_params.pop("batch_size", 64)
+        parallel = self.upload_params.get("parallel", 1)
+        batch_size = self.upload_params.get("batch_size", 64)
 
         self.init_client(
             self.host, distance, self.connection_params, self.upload_params

--- a/engine/clients/milvus/configure.py
+++ b/engine/clients/milvus/configure.py
@@ -35,7 +35,7 @@ class MilvusConfigurator(BaseConfigurator):
         self.client = connections.connect(
             alias=MILVUS_DEFAULT_ALIAS,
             host=host,
-            port=str(connection_params.pop("port", MILVUS_DEFAULT_PORT)),
+            port=str(connection_params.get("port", MILVUS_DEFAULT_PORT)),
             **connection_params,
         )
         print("established connection")

--- a/engine/clients/milvus/search.py
+++ b/engine/clients/milvus/search.py
@@ -25,7 +25,7 @@ class MilvusSearcher(BaseSearcher):
         cls.client = connections.connect(
             alias=MILVUS_DEFAULT_ALIAS,
             host=host,
-            port=str(connection_params.pop("port", MILVUS_DEFAULT_PORT)),
+            port=str(connection_params.get("port", MILVUS_DEFAULT_PORT)),
             **connection_params
         )
         cls.collection = Collection(MILVUS_COLLECTION_NAME, using=MILVUS_DEFAULT_ALIAS)

--- a/engine/clients/milvus/upload.py
+++ b/engine/clients/milvus/upload.py
@@ -33,7 +33,7 @@ class MilvusUploader(BaseUploader):
         cls.client = connections.connect(
             alias=MILVUS_DEFAULT_ALIAS,
             host=host,
-            port=str(connection_params.pop("port", MILVUS_DEFAULT_PORT)),
+            port=str(connection_params.get("port", MILVUS_DEFAULT_PORT)),
             **connection_params
         )
         cls.collection = Collection(MILVUS_COLLECTION_NAME, using=MILVUS_DEFAULT_ALIAS)

--- a/engine/clients/weaviate/configure.py
+++ b/engine/clients/weaviate/configure.py
@@ -22,7 +22,7 @@ class WeaviateConfigurator(BaseConfigurator):
 
     def __init__(self, host, collection_params: dict, connection_params: dict):
         super().__init__(host, collection_params, connection_params)
-        url = f"http://{host}:{connection_params.pop('port', WEAVIATE_DEFAULT_PORT)}"
+        url = f"http://{host}:{connection_params.get('port', WEAVIATE_DEFAULT_PORT)}"
         self.client = Client(url, **connection_params)
 
     def clean(self):

--- a/engine/clients/weaviate/search.py
+++ b/engine/clients/weaviate/search.py
@@ -15,7 +15,7 @@ class WeaviateSearcher(BaseSearcher):
 
     @classmethod
     def init_client(cls, host, distance, connection_params: dict, search_params: dict):
-        url = f"http://{host}:{connection_params.pop('port', WEAVIATE_DEFAULT_PORT)}"
+        url = f"http://{host}:{connection_params.get('port', WEAVIATE_DEFAULT_PORT)}"
         cls.client = Client(url, **connection_params)
         cls.search_params = search_params
 

--- a/engine/clients/weaviate/upload.py
+++ b/engine/clients/weaviate/upload.py
@@ -13,7 +13,7 @@ class WeaviateUploader(BaseUploader):
 
     @classmethod
     def init_client(cls, host, distance, connection_params, upload_params):
-        url = f"http://{host}:{connection_params.pop('port', WEAVIATE_DEFAULT_PORT)}"
+        url = f"http://{host}:{connection_params.get('port', WEAVIATE_DEFAULT_PORT)}"
         cls.client = Client(url, **connection_params)
 
         cls.upload_params = upload_params
@@ -24,9 +24,9 @@ class WeaviateUploader(BaseUploader):
         keys = data_object.keys()
         for key in keys:
             if isinstance(data_object[key], dict):
-                if lat := data_object[key].pop("lat", None):
+                if lat := data_object[key].get("lat", None):
                     data_object[key]["latitude"] = lat
-                if lon := data_object[key].pop("lon", None):
+                if lon := data_object[key].get("lon", None):
                     data_object[key]["longitude"] = lon
 
         return data_object


### PR DESCRIPTION
When multiple datasets are using the same config `parallel` and many other fields aren't preserved.

The above meant for example that if you would do something like:

```
python3 run.py --engines redis-m-* \
  --datasets glove-100-angular --datasets gist-960-euclidean ....
```

For the gist-960-euclidean dataset we would always be benchmarking single client ( and not multiclient with 100 connections ) given the "parallel" property would have been popped before on glove-100-angular run...
I've confirmed this is indeed true and replicable. The fix is easy. swap `pop` by `get`