### PR TITLE
feat: Increase frequency of CI benchmarks to 1hr

### DIFF
--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -4,7 +4,8 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "00 23 * * *"
+    # Run every hour
+    - cron: "0 * * * *"
 
 jobs:
   runBenchmark:

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -4,8 +4,8 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    # Run every hour
-    - cron: "0 * * * *"
+    # Run every 4 hours
+    - cron: "0 */4 * * *"
 
 jobs:
   runBenchmark:

--- a/experiments/configurations/qdrant-vs-weaviate.json
+++ b/experiments/configurations/qdrant-vs-weaviate.json
@@ -1,5 +1,5 @@
 [
-  { 
+  {
     "name": "proposed-config-qdrant-bq-latency",
     "engine": "qdrant",
     "connection_params": { "timeout": 60 },
@@ -27,7 +27,7 @@
     "connection_params": { "timeout": 60 },
     "collection_params": {
       "quantization_config": { "binary": { "always_ram": true } },
-      "optimizers_config": { 
+      "optimizers_config": {
         "max_segment_size": 100000000,
         "default_segment_number":2
       },


### PR DESCRIPTION
This will help with catching bugs faster. Doing once a day isn't enough, once every hour is better.