### PR TITLE
refactor: Update all engines to use Query and Record dataclasses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
       - id: isort
         name: "Sort Imports"
         args: ["--profile", "black"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      # Run the linter.
+      - id: ruff

--- a/engine/base_client/__init__.py
+++ b/engine/base_client/__init__.py
@@ -6,3 +6,12 @@ from engine.base_client.upload import BaseUploader
 
 class IncompatibilityError(Exception):
     pass
+
+
+__all__ = [
+    "BaseClient",
+    "BaseConfigurator",
+    "BaseSearcher",
+    "BaseUploader",
+    "IncompatibilityError",
+]

--- a/engine/base_client/client.py
+++ b/engine/base_client/client.py
@@ -1,7 +1,6 @@
 import json
 import os
 from datetime import datetime
-from pathlib import Path
 from typing import List
 
 from benchmark import ROOT_DIR

--- a/engine/base_client/upload.py
+++ b/engine/base_client/upload.py
@@ -1,6 +1,6 @@
 import time
 from multiprocessing import get_context
-from typing import Iterable, List, Optional
+from typing import Iterable, List
 
 import tqdm
 
@@ -90,9 +90,7 @@ class BaseUploader:
         return {}
 
     @classmethod
-    def upload_batch(
-        cls, ids: List[int], vectors: List[list], metadata: List[Optional[dict]]
-    ):
+    def upload_batch(cls, batch: List[Record]):
         raise NotImplementedError()
 
     @classmethod

--- a/engine/base_client/upload.py
+++ b/engine/base_client/upload.py
@@ -1,6 +1,6 @@
 import time
 from multiprocessing import get_context
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional
 
 import tqdm
 

--- a/engine/base_client/utils.py
+++ b/engine/base_client/utils.py
@@ -1,9 +1,9 @@
-from typing import Iterable
+from typing import Iterable, List
 
 from dataset_reader.base_reader import Record
 
 
-def iter_batches(records: Iterable[Record], n: int) -> Iterable[Record]:
+def iter_batches(records: Iterable[Record], n: int) -> Iterable[List[Record]]:
     batch = []
 
     for record in records:

--- a/engine/base_client/utils.py
+++ b/engine/base_client/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Iterable
 
 from dataset_reader.base_reader import Record
 

--- a/engine/clients/elasticsearch/__init__.py
+++ b/engine/clients/elasticsearch/__init__.py
@@ -1,3 +1,9 @@
 from engine.clients.elasticsearch.configure import ElasticConfigurator
 from engine.clients.elasticsearch.search import ElasticSearcher
 from engine.clients.elasticsearch.upload import ElasticUploader
+
+__all__ = [
+    "ElasticConfigurator",
+    "ElasticSearcher",
+    "ElasticUploader",
+]

--- a/engine/clients/elasticsearch/search.py
+++ b/engine/clients/elasticsearch/search.py
@@ -55,7 +55,7 @@ class ElasticSearcher(BaseSearcher):
             **{"num_candidates": 100, **cls.search_params},
         }
 
-        meta_conditions = cls.parser.parse(meta_conditions)
+        meta_conditions = cls.parser.parse(query.meta_conditions)
         if meta_conditions:
             knn["filter"] = meta_conditions
 

--- a/engine/clients/elasticsearch/search.py
+++ b/engine/clients/elasticsearch/search.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 from elasticsearch import Elasticsearch
 
+from dataset_reader.base_reader import Query
 from engine.base_client.search import BaseSearcher
 from engine.clients.elasticsearch.config import (
     ELASTIC_INDEX,
@@ -46,10 +47,10 @@ class ElasticSearcher(BaseSearcher):
         cls.search_params = search_params
 
     @classmethod
-    def search_one(cls, vector, meta_conditions, top) -> List[Tuple[int, float]]:
+    def search_one(cls, query: Query, top: int) -> List[Tuple[int, float]]:
         knn = {
             "field": "vector",
-            "query_vector": vector,
+            "query_vector": query.vector,
             "k": top,
             **{"num_candidates": 100, **cls.search_params},
         }

--- a/engine/clients/elasticsearch/upload.py
+++ b/engine/clients/elasticsearch/upload.py
@@ -48,7 +48,7 @@ class ElasticUploader(BaseUploader):
     def upload_batch(cls, batch: List[Record]):
         operations = []
         for record in batch:
-            vector_id = uuid.UUID(int=record.idx).hex
+            vector_id = uuid.UUID(int=record.id).hex
             operations.append({"index": {"_id": vector_id}})
             operations.append({"vector": record.vector, **(record.metadata or {})})
 

--- a/engine/clients/elasticsearch/upload.py
+++ b/engine/clients/elasticsearch/upload.py
@@ -1,6 +1,6 @@
 import multiprocessing as mp
 import uuid
-from typing import List, Optional
+from typing import List
 
 from elasticsearch import Elasticsearch
 
@@ -46,8 +46,6 @@ class ElasticUploader(BaseUploader):
 
     @classmethod
     def upload_batch(cls, batch: List[Record]):
-        if metadata is None:
-            metadata = [{}] * len(batch)
         operations = []
         for record in batch:
             vector_id = uuid.UUID(int=record.idx).hex

--- a/engine/clients/milvus/__init__.py
+++ b/engine/clients/milvus/__init__.py
@@ -1,3 +1,9 @@
 from engine.clients.milvus.configure import MilvusConfigurator
 from engine.clients.milvus.search import MilvusSearcher
 from engine.clients.milvus.upload import MilvusUploader
+
+__all__ = [
+    "MilvusConfigurator",
+    "MilvusSearcher",
+    "MilvusUploader",
+]

--- a/engine/clients/milvus/search.py
+++ b/engine/clients/milvus/search.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 
 from pymilvus import Collection, connections
 
+from dataset_reader.base_reader import Query
 from engine.base_client.search import BaseSearcher
 from engine.clients.milvus.config import (
     DISTANCE_MAPPING,
@@ -37,15 +38,15 @@ class MilvusSearcher(BaseSearcher):
         return "forkserver" if "forkserver" in mp.get_all_start_methods() else "spawn"
 
     @classmethod
-    def search_one(cls, vector, meta_conditions, top) -> List[Tuple[int, float]]:
+    def search_one(cls, query: Query, top: int) -> List[Tuple[int, float]]:
         param = {"metric_type": cls.distance, "params": cls.search_params["params"]}
         try:
             res = cls.collection.search(
-                data=[vector],
+                data=[query.vector],
                 anns_field="vector",
                 param=param,
                 limit=top,
-                expr=cls.parser.parse(meta_conditions),
+                expr=cls.parser.parse(query.meta_conditions),
             )
         except Exception as e:
             import ipdb

--- a/engine/clients/milvus/upload.py
+++ b/engine/clients/milvus/upload.py
@@ -44,7 +44,6 @@ class MilvusUploader(BaseUploader):
     @classmethod
     def upload_batch(cls, batch: List[Record]):
         has_metadata = any(record.metadata for record in batch)
-        field_values = []
         if has_metadata:
             field_values = [
                 [
@@ -60,7 +59,7 @@ class MilvusUploader(BaseUploader):
 
         ids, vectors = [], []
         for record in batch:
-            ids.append(record.idx)
+            ids.append(record.id)
             vectors.append(record.vector)
 
         cls.collection.insert([ids, vectors] + field_values)

--- a/engine/clients/milvus/upload.py
+++ b/engine/clients/milvus/upload.py
@@ -44,6 +44,7 @@ class MilvusUploader(BaseUploader):
     @classmethod
     def upload_batch(cls, batch: List[Record]):
         has_metadata = any(record.metadata for record in batch)
+        field_values = []
         if has_metadata:
             field_values = [
                 [
@@ -56,8 +57,12 @@ class MilvusUploader(BaseUploader):
             ]
         else:
             field_values = []
-        ids = [record.idx for record in batch]
-        vectors = [record.vector for record in batch]
+
+        ids, vectors = [], []
+        for record in batch:
+            ids.append(record.idx)
+            vectors.append(record.vector)
+
         cls.collection.insert([ids, vectors] + field_values)
 
     @classmethod

--- a/engine/clients/milvus/upload.py
+++ b/engine/clients/milvus/upload.py
@@ -1,5 +1,5 @@
 import multiprocessing as mp
-from typing import List, Optional
+from typing import List
 
 from pymilvus import (
     Collection,

--- a/engine/clients/opensearch/__init__.py
+++ b/engine/clients/opensearch/__init__.py
@@ -1,3 +1,9 @@
 from engine.clients.opensearch.configure import OpenSearchConfigurator
 from engine.clients.opensearch.search import OpenSearchSearcher
 from engine.clients.opensearch.upload import OpenSearchUploader
+
+__all__ = [
+    "OpenSearchConfigurator",
+    "OpenSearchSearcher",
+    "OpenSearchUploader",
+]

--- a/engine/clients/opensearch/search.py
+++ b/engine/clients/opensearch/search.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 from opensearchpy import OpenSearch
 
+from dataset_reader.base_reader import Query
 from engine.base_client.search import BaseSearcher
 from engine.clients.opensearch.config import (
     OPENSEARCH_INDEX,
@@ -46,11 +47,11 @@ class OpenSearchSearcher(BaseSearcher):
         cls.search_params = search_params
 
     @classmethod
-    def search_one(cls, vector, meta_conditions, top) -> List[Tuple[int, float]]:
+    def search_one(cls, query: Query, top: int) -> List[Tuple[int, float]]:
         query = {
             "knn": {
                 "vector": {
-                    "vector": vector,
+                    "vector": query.vector,
                     "k": top,
                 }
             }

--- a/engine/clients/opensearch/search.py
+++ b/engine/clients/opensearch/search.py
@@ -48,7 +48,7 @@ class OpenSearchSearcher(BaseSearcher):
 
     @classmethod
     def search_one(cls, query: Query, top: int) -> List[Tuple[int, float]]:
-        query = {
+        opensearch_query = {
             "knn": {
                 "vector": {
                     "vector": query.vector,
@@ -59,9 +59,9 @@ class OpenSearchSearcher(BaseSearcher):
 
         meta_conditions = cls.parser.parse(query.meta_conditions)
         if meta_conditions:
-            query = {
+            opensearch_query = {
                 "bool": {
-                    "must": [query],
+                    "must": [opensearch_query],
                     "filter": meta_conditions,
                 }
             }
@@ -69,7 +69,7 @@ class OpenSearchSearcher(BaseSearcher):
         res = cls.client.search(
             index=OPENSEARCH_INDEX,
             body={
-                "query": query,
+                "query": opensearch_query,
                 "size": top,
             },
             params={

--- a/engine/clients/opensearch/search.py
+++ b/engine/clients/opensearch/search.py
@@ -57,7 +57,7 @@ class OpenSearchSearcher(BaseSearcher):
             }
         }
 
-        meta_conditions = cls.parser.parse(meta_conditions)
+        meta_conditions = cls.parser.parse(query.meta_conditions)
         if meta_conditions:
             query = {
                 "bool": {

--- a/engine/clients/opensearch/upload.py
+++ b/engine/clients/opensearch/upload.py
@@ -46,8 +46,6 @@ class OpenSearchUploader(BaseUploader):
 
     @classmethod
     def upload_batch(cls, batch: List[Record]):
-        if metadata is None:
-            metadata = [{}] * len(batch)
         operations = []
         for record in batch:
             vector_id = uuid.UUID(int=record.id).hex

--- a/engine/clients/pgvector/configure.py
+++ b/engine/clients/pgvector/configure.py
@@ -46,7 +46,9 @@ class PgVectorConfigurator(BaseConfigurator):
             )
 
         self.conn.execute(
-            f"CREATE INDEX on items USING hnsw(embedding {hnsw_distance_type}) WITH (m = {collection_params['hnsw_config']['m']}, ef_construction = {collection_params['hnsw_config']['ef_construct']})"
+            f"CREATE INDEX on items USING hnsw(embedding {hnsw_distance_type}) WITH "
+            f"(m = {collection_params['hnsw_config']['m']}, "
+            f"ef_construction = {collection_params['hnsw_config']['ef_construct']})"
         )
 
         self.conn.close()

--- a/engine/clients/pgvector/search.py
+++ b/engine/clients/pgvector/search.py
@@ -5,6 +5,7 @@ import numpy as np
 import psycopg
 from pgvector.psycopg import register_vector
 
+from dataset_reader.base_reader import Query
 from engine.base_client.distances import Distance
 from engine.base_client.search import BaseSearcher
 from engine.clients.pgvector.config import get_db_config
@@ -27,19 +28,19 @@ class PgVectorSearcher(BaseSearcher):
         cls.search_params = search_params["search_params"]
 
     @classmethod
-    def search_one(cls, vector, meta_conditions, top) -> List[Tuple[int, float]]:
+    def search_one(cls, query: Query, top: int) -> List[Tuple[int, float]]:
         cls.cur.execute(f"SET hnsw.ef_search = {cls.search_params['hnsw_ef']}")
 
         if cls.distance == Distance.COSINE:
-            query = f"SELECT id, embedding <=> %s AS _score FROM items ORDER BY _score LIMIT {top};"
+            sql_query = f"SELECT id, embedding <=> %s AS _score FROM items ORDER BY _score LIMIT {top};"
         elif cls.distance == Distance.L2:
-            query = f"SELECT id, embedding <-> %s AS _score FROM items ORDER BY _score LIMIT {top};"
+            sql_query = f"SELECT id, embedding <-> %s AS _score FROM items ORDER BY _score LIMIT {top};"
         else:
             raise NotImplementedError(f"Unsupported distance metric {cls.distance}")
 
         cls.cur.execute(
-            query,
-            (np.array(vector),),
+            sql_query,
+            (np.array(query.vector),),
         )
         return cls.cur.fetchall()
 

--- a/engine/clients/pgvector/search.py
+++ b/engine/clients/pgvector/search.py
@@ -1,4 +1,3 @@
-import multiprocessing as mp
 from typing import List, Tuple
 
 import numpy as np

--- a/engine/clients/pgvector/upload.py
+++ b/engine/clients/pgvector/upload.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 import psycopg
@@ -23,12 +23,10 @@ class PgVectorUploader(BaseUploader):
 
     @classmethod
     def upload_batch(cls, batch: List[Record]):
-        vectors = np.array(vectors)
-
         # Copy is faster than insert
         with cls.cur.copy("COPY items (id, embedding) FROM STDIN") as copy:
             for record in batch:
-                copy.write_row((record.id, record.vector))
+                copy.write_row((record.id, np.array(record.vector)))
 
     @classmethod
     def delete_client(cls):

--- a/engine/clients/pgvector/upload.py
+++ b/engine/clients/pgvector/upload.py
@@ -4,6 +4,7 @@ import numpy as np
 import psycopg
 from pgvector.psycopg import register_vector
 
+from dataset_reader.base_reader import Record
 from engine.base_client.upload import BaseUploader
 from engine.clients.pgvector.config import get_db_config
 
@@ -21,15 +22,13 @@ class PgVectorUploader(BaseUploader):
         cls.upload_params = upload_params
 
     @classmethod
-    def upload_batch(
-        cls, ids: List[int], vectors: List[list], metadata: Optional[List[dict]]
-    ):
+    def upload_batch(cls, batch: List[Record]):
         vectors = np.array(vectors)
 
         # Copy is faster than insert
         with cls.cur.copy("COPY items (id, embedding) FROM STDIN") as copy:
-            for i, embedding in zip(ids, vectors):
-                copy.write_row((i, embedding))
+            for record in batch:
+                copy.write_row((record.id, record.vector))
 
     @classmethod
     def delete_client(cls):

--- a/engine/clients/qdrant/__init__.py
+++ b/engine/clients/qdrant/__init__.py
@@ -1,3 +1,9 @@
 from engine.clients.qdrant.configure import QdrantConfigurator
 from engine.clients.qdrant.search import QdrantSearcher
 from engine.clients.qdrant.upload import QdrantUploader
+
+__all__ = [
+    "QdrantConfigurator",
+    "QdrantSearcher",
+    "QdrantUploader",
+]

--- a/engine/clients/qdrant/search.py
+++ b/engine/clients/qdrant/search.py
@@ -35,7 +35,7 @@ class QdrantSearcher(BaseSearcher):
     #     return "forkserver" if "forkserver" in mp.get_all_start_methods() else "spawn"
 
     @classmethod
-    def search_one(cls, query: Query, top) -> List[Tuple[int, float]]:
+    def search_one(cls, query: Query, top: int) -> List[Tuple[int, float]]:
         # Can query only one till we introduce re-ranking in the benchmarks
         if query.sparse_vector is None:
             query_vector = query.vector

--- a/engine/clients/qdrant/upload.py
+++ b/engine/clients/qdrant/upload.py
@@ -46,7 +46,7 @@ class QdrantUploader(BaseUploader):
             vectors.append(vector)
             payloads.append(point.metadata or {})
 
-        res = cls.client.upsert(
+        _ = cls.client.upsert(
             collection_name=QDRANT_COLLECTION_NAME,
             points=Batch.model_construct(
                 ids=ids,

--- a/engine/clients/redis/__init__.py
+++ b/engine/clients/redis/__init__.py
@@ -1,3 +1,9 @@
 from engine.clients.redis.configure import RedisConfigurator
 from engine.clients.redis.search import RedisSearcher
 from engine.clients.redis.upload import RedisUploader
+
+__all__ = [
+    "RedisConfigurator",
+    "RedisSearcher",
+    "RedisUploader",
+]

--- a/engine/clients/redis/search.py
+++ b/engine/clients/redis/search.py
@@ -1,5 +1,5 @@
 import random
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 from redis import Redis, RedisCluster

--- a/engine/clients/redis/search.py
+++ b/engine/clients/redis/search.py
@@ -1,10 +1,10 @@
 import random
-from typing import List, Tuple, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from redis import Redis, RedisCluster
-from redis.commands.search.query import Query as RedisQuery
 from redis.commands.search import Search as RedisSearchIndex
+from redis.commands.search.query import Query as RedisQuery
 
 from dataset_reader.base_reader import Query as DatasetQuery
 from engine.base_client.search import BaseSearcher

--- a/engine/clients/redis/search.py
+++ b/engine/clients/redis/search.py
@@ -22,8 +22,8 @@ class RedisSearcher(BaseSearcher):
     search_params = {}
     client: Union[RedisCluster, Redis] = None
     parser = RedisConditionParser()
+    knn_conditions = "EF_RUNTIME $EF"
 
-    knn_conditions: str
     is_cluster: bool
     conns: List[Union[RedisCluster, Redis]]
     search_namespace: RedisSearchIndex
@@ -48,7 +48,6 @@ class RedisSearcher(BaseSearcher):
 
         cls.is_cluster = REDIS_CLUSTER
         cls.search_namespace = random.choice(cls.conns).ft()
-        cls.knn_conditions = "EF_RUNTIME $EF"
 
     @classmethod
     def search_one(cls, query: DatasetQuery, top: int) -> List[Tuple[int, float]]:

--- a/engine/clients/redis/upload.py
+++ b/engine/clients/redis/upload.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 from redis import Redis, RedisCluster

--- a/engine/clients/redis/upload.py
+++ b/engine/clients/redis/upload.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import numpy as np
 from redis import Redis, RedisCluster
 
+from dataset_reader.base_reader import Record
 from engine.base_client.upload import BaseUploader
 from engine.clients.redis.config import (
     REDIS_AUTH,
@@ -26,14 +27,12 @@ class RedisUploader(BaseUploader):
         cls.upload_params = upload_params
 
     @classmethod
-    def upload_batch(
-        cls, ids: List[int], vectors: List[list], metadata: Optional[List[dict]]
-    ):
+    def upload_batch(cls, batch: List[Record]):
         p = cls.client.pipeline(transaction=False)
-        for i in range(len(ids)):
-            idx = ids[i]
-            vec = vectors[i]
-            meta = metadata[i] if metadata else {}
+        for record in batch:
+            idx = record.id
+            vec = record.vector
+            meta = record.metadata or {}
             geopoints = {}
             payload = {}
             if meta is not None:

--- a/engine/clients/weaviate/__init__.py
+++ b/engine/clients/weaviate/__init__.py
@@ -1,3 +1,9 @@
 from engine.clients.weaviate.configure import WeaviateConfigurator
 from engine.clients.weaviate.search import WeaviateSearcher
 from engine.clients.weaviate.upload import WeaviateUploader
+
+__all__ = [
+    "WeaviateConfigurator",
+    "WeaviateSearcher",
+    "WeaviateUploader",
+]

--- a/engine/clients/weaviate/search.py
+++ b/engine/clients/weaviate/search.py
@@ -32,10 +32,10 @@ class WeaviateSearcher(BaseSearcher):
         cls.client = client
 
     @classmethod
-    def search_one(self, query: Query, top: int) -> List[Tuple[int, float]]:
-        res = self.collection.query.near_vector(
+    def search_one(cls, query: Query, top: int) -> List[Tuple[int, float]]:
+        res = cls.collection.query.near_vector(
             near_vector=query.vector,
-            filters=self.parser.parse(query.meta_conditions),
+            filters=cls.parser.parse(query.meta_conditions),
             limit=top,
             return_metadata=MetadataQuery(distance=True),
             return_properties=[],

--- a/engine/clients/weaviate/search.py
+++ b/engine/clients/weaviate/search.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import List, Tuple
 
 from weaviate import WeaviateClient

--- a/engine/clients/weaviate/search.py
+++ b/engine/clients/weaviate/search.py
@@ -7,6 +7,7 @@ from weaviate.classes.query import MetadataQuery
 from weaviate.collections import Collection
 from weaviate.connect import ConnectionParams
 
+from dataset_reader.base_reader import Query
 from engine.base_client.search import BaseSearcher
 from engine.clients.weaviate.config import WEAVIATE_CLASS_NAME, WEAVIATE_DEFAULT_PORT
 from engine.clients.weaviate.parser import WeaviateConditionParser
@@ -32,10 +33,10 @@ class WeaviateSearcher(BaseSearcher):
         cls.client = client
 
     @classmethod
-    def search_one(self, vector, meta_conditions, top) -> List[Tuple[int, float]]:
+    def search_one(self, query: Query, top: int) -> List[Tuple[int, float]]:
         res = self.collection.query.near_vector(
-            near_vector=vector,
-            filters=self.parser.parse(meta_conditions),
+            near_vector=query.vector,
+            filters=self.parser.parse(query.meta_conditions),
             limit=top,
             return_metadata=MetadataQuery(distance=True),
             return_properties=[],

--- a/engine/clients/weaviate/upload.py
+++ b/engine/clients/weaviate/upload.py
@@ -5,6 +5,7 @@ from weaviate import WeaviateClient
 from weaviate.classes.data import DataObject
 from weaviate.connect import ConnectionParams
 
+from dataset_reader.base_reader import Record
 from engine.base_client.upload import BaseUploader
 from engine.clients.weaviate.config import WEAVIATE_CLASS_NAME, WEAVIATE_DEFAULT_PORT
 
@@ -28,14 +29,14 @@ class WeaviateUploader(BaseUploader):
         )
 
     @classmethod
-    def upload_batch(
-        cls, ids: List[int], vectors: List[list], metadata: List[Optional[dict]]
-    ):
+    def upload_batch(cls, batch: List[Record]):
         objects = []
-        for i in range(len(ids)):
-            id = uuid.UUID(int=ids[i])
-            property = metadata[i] or {}
-            objects.append(DataObject(properties=property, vector=vectors[i], uuid=id))
+        for record in batch:
+            id = uuid.UUID(int=record.id)
+            property = record.metadata or {}
+            objects.append(
+                DataObject(properties=property, vector=record.vector, uuid=id)
+            )
         if len(objects) > 0:
             cls.collection.data.insert_many(objects)
 

--- a/engine/clients/weaviate/upload.py
+++ b/engine/clients/weaviate/upload.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List, Optional
+from typing import List
 
 from weaviate import WeaviateClient
 from weaviate.classes.data import DataObject

--- a/engine/clients/weaviate/upload.py
+++ b/engine/clients/weaviate/upload.py
@@ -32,10 +32,10 @@ class WeaviateUploader(BaseUploader):
     def upload_batch(cls, batch: List[Record]):
         objects = []
         for record in batch:
-            id = uuid.UUID(int=record.id)
-            property = record.metadata or {}
+            _id = uuid.UUID(int=record.id)
+            _property = record.metadata or {}
             objects.append(
-                DataObject(properties=property, vector=record.vector, uuid=id)
+                DataObject(properties=_property, vector=record.vector, uuid=_id)
             )
         if len(objects) > 0:
             cls.collection.data.insert_many(objects)

--- a/run.py
+++ b/run.py
@@ -76,7 +76,7 @@ def run(
                     f"Skipping {engine_name} - {dataset_name}, incompatible params:", e
                 )
                 continue
-            except KeyboardInterrupt as e:
+            except KeyboardInterrupt:
                 traceback.print_exc()
                 exit(1)
             except Exception as e:


### PR DESCRIPTION
This PR does two things:
- Use `Query` and `Record` in all the engines. 
- Introduces [Ruff](https://docs.astral.sh/ruff/) linter (written in Rust :crab: ) in precommit hooks to run type checks and help maintain code quality.

Part of sparse vectors CI benchmark PR. https://github.com/qdrant/vector-db-benchmark/pull/114