### PR TITLE
refactoring: refactor sparse vector support

### DIFF
--- a/engine/base_client/client.py
+++ b/engine/base_client/client.py
@@ -24,14 +24,16 @@ class BaseClient:
         configurator: BaseConfigurator,
         uploader: BaseUploader,
         searchers: List[BaseSearcher],
-        supports_sparse_vectors: bool,
     ):
         self.name = name
         self.configurator = configurator
         self.uploader = uploader
         self.searchers = searchers
         self.engine = engine
-        self.supports_sparse_vectors = supports_sparse_vectors
+
+    @property
+    def sparse_vector_support(self):
+        return self.configurator.SPARSE_VECTOR_SUPPORT
 
     def save_search_results(
         self, dataset_name: str, results: dict, search_id: int, search_params: dict

--- a/engine/base_client/configure.py
+++ b/engine/base_client/configure.py
@@ -4,6 +4,7 @@ from benchmark.dataset import Dataset
 
 
 class BaseConfigurator:
+    SPARSE_VECTOR_SUPPORT: bool = False
     DISTANCE_MAPPING = {}
 
     def __init__(self, host, collection_params: dict, connection_params: dict):

--- a/engine/clients/client_factory.py
+++ b/engine/clients/client_factory.py
@@ -61,8 +61,6 @@ ENGINE_SEARCHERS = {
     "pgvector": PgVectorSearcher,
 }
 
-ENGINES_WITH_SPARSE_VECTOR_SUPPORT = ["qdrant"]
-
 
 class ClientFactory(ABC):
     def __init__(self, host):
@@ -111,7 +109,4 @@ class ClientFactory(ABC):
             configurator=self._create_configurator(experiment),
             uploader=self._create_uploader(experiment),
             searchers=self._create_searchers(experiment),
-            supports_sparse_vectors=(
-                experiment["engine"] in ENGINES_WITH_SPARSE_VECTOR_SUPPORT
-            ),
         )

--- a/engine/clients/qdrant/configure.py
+++ b/engine/clients/qdrant/configure.py
@@ -8,6 +8,7 @@ from engine.clients.qdrant.config import QDRANT_COLLECTION_NAME
 
 
 class QdrantConfigurator(BaseConfigurator):
+    SPARSE_VECTOR_SUPPORT = True
     DISTANCE_MAPPING = {
         Distance.L2: rest.Distance.EUCLID,
         Distance.COSINE: rest.Distance.COSINE,

--- a/run.py
+++ b/run.py
@@ -47,15 +47,15 @@ def run(
             print(f"Running experiment: {engine_name} - {dataset_name}")
             client = ClientFactory(host).build_client(engine_config)
             try:
+
+                dataset = Dataset(dataset_config)
                 if (
-                    dataset_config["type"] == "sparse"
-                    and not client.supports_sparse_vectors
+                    dataset_config.type == "sparse"
+                    and not client.sparse_vector_support
                 ):
                     raise IncompatibilityError(
                         f"{client.name} engine does not support sparse vectors"
                     )
-
-                dataset = Dataset(dataset_config)
                 dataset.download()
 
                 with stopit.ThreadingTimeout(timeout) as tt:

--- a/run.py
+++ b/run.py
@@ -49,10 +49,7 @@ def run(
             try:
 
                 dataset = Dataset(dataset_config)
-                if (
-                    dataset_config.type == "sparse"
-                    and not client.sparse_vector_support
-                ):
+                if dataset_config.type == "sparse" and not client.sparse_vector_support:
                     raise IncompatibilityError(
                         f"{client.name} engine does not support sparse vectors"
                     )


### PR DESCRIPTION
I feel like sparse vector support should not be in `__init__`
I tried this naming, it seems to be better for the configurator classes, but worse for the client class, idk, feel free to change it back if you want