### PR TITLE
feat: Force docker image removal

### DIFF
--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -23,7 +23,7 @@ if [[ -z "$PRIVATE_IP_OF_THE_SERVER" ]]; then
   exit 1
 fi
 
-docker rmi qdrant/vector-db-benchmark:latest || true
+docker rmi --force qdrant/vector-db-benchmark:latest || true
 
 docker run \
   --rm \


### PR DESCRIPTION
Otherwise it fails silently and ends up using the old container:

```
Error response from daemon: conflict: unable to remove repository reference "qdrant/vector-db-benchmark:latest" (must force) - container b6bbafc6355b is using its referenced image 24afca33f44f
```