### PR TITLE
Weaviate version 1.25.1

### DIFF
--- a/engine/servers/weaviate-single-node/docker-compose.yaml
+++ b/engine/servers/weaviate-single-node/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - '8090'
     - --scheme
     - http
-    image: cr.weaviate.io/semitechnologies/weaviate:1.24.1
+    image: cr.weaviate.io/semitechnologies/weaviate:1.25.1
     network_mode: host
     logging:
       driver: "json-file"

--- a/engine/servers/weaviate-single-node/docker-compose.yaml
+++ b/engine/servers/weaviate-single-node/docker-compose.yaml
@@ -13,8 +13,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-file: 1
-        max-size: 10m
+        max-file: "1"
+        max-size: "10m"
     environment:
       QUERY_DEFAULTS_LIMIT: 10
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'


### PR DESCRIPTION
- Following up on https://weaviate.io/blog/weaviate-1-25-release 
- Confirmed that the  weaviate-client==4.6.3 and this PR works as expected