### PR TITLE
Collect memory usage after import. Added example on redis client integration

### DIFF
--- a/engine/base_client/upload.py
+++ b/engine/base_client/upload.py
@@ -70,6 +70,7 @@ class BaseUploader:
 
         print(f"Total import time: {total_time}")
 
+        memory_usage = self.get_memory_usage()
         self.delete_client()
 
         return {
@@ -77,6 +78,7 @@ class BaseUploader:
             "upload_time": upload_time,
             "total_time": total_time,
             "latencies": latencies,
+            "memory_usage": memory_usage,
         }
 
     @classmethod
@@ -87,6 +89,10 @@ class BaseUploader:
 
     @classmethod
     def post_upload(cls, distance):
+        return {}
+
+    @classmethod
+    def get_memory_usage(cls):
         return {}
 
     @classmethod

--- a/engine/clients/redis/upload.py
+++ b/engine/clients/redis/upload.py
@@ -16,6 +16,7 @@ from engine.clients.redis.helper import convert_to_redis_coords
 
 class RedisUploader(BaseUploader):
     client = None
+    client_decode = None
     upload_params = {}
 
     @classmethod
@@ -23,6 +24,13 @@ class RedisUploader(BaseUploader):
         redis_constructor = RedisCluster if REDIS_CLUSTER else Redis
         cls.client = redis_constructor(
             host=host, port=REDIS_PORT, password=REDIS_AUTH, username=REDIS_USER
+        )
+        cls.client_decode = redis_constructor(
+            host=host,
+            port=REDIS_PORT,
+            password=REDIS_AUTH,
+            username=REDIS_USER,
+            decode_responses=True,
         )
         cls.upload_params = upload_params
 
@@ -67,3 +75,8 @@ class RedisUploader(BaseUploader):
     @classmethod
     def post_upload(cls, _distance):
         return {}
+
+    def get_memory_usage(cls):
+        used_memory = cls.client_decode.info("memory")["used_memory"]
+        index_info = cls.client_decode.ft().info()
+        return {"used_memory": used_memory, "index_info": index_info}


### PR DESCRIPTION
The following PR allows the client implementations to report memory usage metrics at the end of import stage. 
It can also be used to add extra info on the post upload stage. 
As an example, on the redis client, we're preserving both the full memory usage also, but all the index info that contains the breakdown of memory usage per component.  