### PR TITLE
fix: Temporarily disable dbpedia openai BQ benchmarking

### DIFF
--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -26,7 +26,7 @@ jobs:
             DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
             DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
             DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
-            DATASET_TO_ENGINE["dbpedia-openai-1M-1536-angular"]="qdrant-bq-continuous-benchmark"
+            # DATASET_TO_ENGINE["dbpedia-openai-1M-1536-angular"]="qdrant-bq-continuous-benchmark"
 
             for dataset in "${!DATASET_TO_ENGINE[@]}"; do
               export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}


### PR DESCRIPTION
```console
numpy.core._exceptions._ArrayMemoryError: Unable to allocate 5.58 GiB for an array with shape (1497600000,) and data type float32
Traceback (most recent call last):

  File "/code/run.py", line 91, in <module>
    app()

  File "/code/run.py", line 86, in run
    raise e

  File "/code/run.py", line 59, in run
    client.run_experiment(

  File "/code/engine/base_client/client.py", line 108, in run_experiment
    upload_stats = self.uploader.upload(

  File "/code/engine/base_client/upload.py", line 56, in upload
    latencies = list(

  File "/usr/local/lib/python3.10/multiprocessing/pool.py", line 873, in next
    raise value

numpy.core._exceptions._ArrayMemoryError: Unable to allocate 5.58 GiB for an array with shape (1497600000,) and data type float32

```