### PR TITLE
feat: Add DBpedia OpenAI embedding dataset with 100k vectors

### DIFF
--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -26,7 +26,7 @@ jobs:
             DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
             DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
             DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
-            DATASET_TO_ENGINE["dbpedia-openai-1M-1536-angular"]="qdrant-bq-continuous-benchmark"
+            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
 
             for dataset in "${!DATASET_TO_ENGINE[@]}"; do
               export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}

--- a/datasets/datasets.json
+++ b/datasets/datasets.json
@@ -67,6 +67,14 @@
     "link": "https://storage.googleapis.com/ann-filtered-benchmark/datasets/dbpedia_openai_1M.tgz"
   },
   {
+    "name": "dbpedia-openai-100K-1536-angular",
+    "vector_size": 1536,
+    "distance": "cosine",
+    "type": "tar",
+    "path": "dbpedia-openai-100K-1536-angular/dbpedia_openai_100K",
+    "link": "https://storage.googleapis.com/ann-filtered-benchmark/datasets/dbpedia_openai_100K.tgz"
+  },
+  {
     "name": "msmarco-sparse-100K",
     "type": "sparse",
     "path": "msmarco-sparse/100K",


### PR DESCRIPTION
Reasoning:
- Using a smaller dataset means it will finish faster. 
  - This is also important because our crons run every 4 hours and the runs shouldn't overlap because they use the same machine
- All other CI benchmark datasets are of similar size (<1GB)
