### PR TITLE
feat: Add 15m timeout for CI benchmarks

### DIFF
--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -48,3 +48,23 @@ jobs:
       - name: Fail job if any of the benches failed
         if: steps.benches.outputs.failed == 'true'
         run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks failed or timed out.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -67,5 +67,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-        if: steps.benches.outputs.failed == 'error'
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -46,7 +46,7 @@ jobs:
 
             set -e
       - name: Fail job if any of the benches failed
-        if: steps.benches.outputs.failed == 'true'
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
         run: exit 1
       - name: Send Notification
         if: failure() || cancelled()
@@ -60,11 +60,12 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "CI benchmarks failed or timed out.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                    "text": "CI benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
                   }
                 }
               ]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+        if: steps.benches.outputs.failed == 'error'
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Benches
+        id: benches
         run: |
             export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
             export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
@@ -28,15 +29,22 @@ jobs:
             DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
             DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
 
+            set +e
+
             for dataset in "${!DATASET_TO_ENGINE[@]}"; do
               export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
               export DATASETS=$dataset
 
               # Benchmark the dev branch:
               export QDRANT_VERSION=ghcr/dev
-              bash -x tools/run_ci.sh
+              timeout 15m bash -x tools/run_ci.sh
 
               # Benchmark the master branch:
               export QDRANT_VERSION=docker/master
-              bash -x tools/run_ci.sh
+              timeout 15m bash -x tools/run_ci.sh
             done
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'true'
+        run: exit 1

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+function handle_error() {
+  echo "Error occured ${QDRANT_VERSION[@]} ${ENGINE_NAME[@]} ${DATASETS[@]}"
+  echo "::set-output name=failed::true"
+}
+
+function handle_term() {
+  echo "Timeout occured ${QDRANT_VERSION[@]} ${ENGINE_NAME[@]} ${DATASETS[@]}"
+  echo "::set-output name=failed::true"
+}
+
+trap handle_err ERR
+trap handle_term TERM
+
 # Script, that runs benchmark within the GitHub Actions CI environment
 
 SCRIPT=$(realpath "$0")

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -12,8 +12,8 @@ function handle_term() {
   echo "::set-output name=failed::true"
 }
 
-trap handle_err ERR
-trap handle_term TERM
+trap 'handle_err' ERR
+trap 'handle_term' TERM
 
 # Script, that runs benchmark within the GitHub Actions CI environment
 

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -3,13 +3,13 @@
 set -e
 
 function handle_error() {
-  echo "Error occured ${QDRANT_VERSION[@]} ${ENGINE_NAME[@]} ${DATASETS[@]}"
-  echo "::set-output name=failed::true"
+  echo "Error occured ${QDRANT_VERSION@A} ${ENGINE_NAME@A} ${DATASETS@A}"
+  echo "{failed}={error}" >> $GITHUB_OUTPUT
 }
 
 function handle_term() {
-  echo "Timeout occured ${QDRANT_VERSION[@]} ${ENGINE_NAME[@]} ${DATASETS[@]}"
-  echo "::set-output name=failed::true"
+  echo "Timeout occured ${QDRANT_VERSION@A} ${ENGINE_NAME@A} ${DATASETS@A}"
+  echo "{failed}={timeout}" >> $GITHUB_OUTPUT
 }
 
 trap 'handle_err' ERR


### PR DESCRIPTION
Due to some issues. Some of the datasets are taking forever to index. This also stops other datasets from running because  we schedule a cron every 4hours. So I think it's a good idea that we introduce timeouts of 15m for each run.

This PR also introduces a Slack alert in case the workflow doesn't run as expected (error or timeout)