### PR TITLE
Enable specifying the max_optimization_threads on post_upload() method for better indexing times on VMs with large CPU count

### DIFF
--- a/engine/clients/qdrant/config.py
+++ b/engine/clients/qdrant/config.py
@@ -1,3 +1,24 @@
 import os
+import random
+import time
 
 QDRANT_COLLECTION_NAME = os.getenv("QDRANT_COLLECTION_NAME", "benchmark")
+QDRANT_MAX_OPTIMIZATION_THREADS = os.getenv("QDRANT_MAX_OPTIMIZATION_THREADS", None)
+
+
+def retry_with_exponential_backoff(
+    func, *args, max_retries=10, base_delay=1, max_delay=90, **kwargs
+):
+    retries = 0
+    while retries < max_retries:
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            delay = min(base_delay * 2**retries + random.uniform(0, 1), max_delay)
+            time.sleep(delay)
+            retries += 1
+            print(f"received the following exception on try #{retries}: {e.__str__}")
+            if retries == max_retries:
+                raise e
+            else:
+                print("retrying...")

--- a/engine/clients/qdrant/configure.py
+++ b/engine/clients/qdrant/configure.py
@@ -4,7 +4,10 @@ from qdrant_client.http import models as rest
 from benchmark.dataset import Dataset
 from engine.base_client.configure import BaseConfigurator
 from engine.base_client.distances import Distance
-from engine.clients.qdrant.config import QDRANT_COLLECTION_NAME
+from engine.clients.qdrant.config import (
+    QDRANT_COLLECTION_NAME,
+    retry_with_exponential_backoff,
+)
 
 
 class QdrantConfigurator(BaseConfigurator):
@@ -52,7 +55,8 @@ class QdrantConfigurator(BaseConfigurator):
                 )
             }
 
-        self.client.recreate_collection(
+        retry_with_exponential_backoff(
+            self.client.recreate_collection,
             collection_name=QDRANT_COLLECTION_NAME,
             **vectors_config,
             **self.collection_params

--- a/engine/clients/qdrant/upload.py
+++ b/engine/clients/qdrant/upload.py
@@ -13,7 +13,10 @@ from qdrant_client.http.models import (
 
 from dataset_reader.base_reader import Record
 from engine.base_client.upload import BaseUploader
-from engine.clients.qdrant.config import QDRANT_COLLECTION_NAME
+from engine.clients.qdrant.config import (
+    QDRANT_COLLECTION_NAME,
+    QDRANT_MAX_OPTIMIZATION_THREADS,
+)
 
 
 class QdrantUploader(BaseUploader):
@@ -58,14 +61,15 @@ class QdrantUploader(BaseUploader):
 
     @classmethod
     def post_upload(cls, _distance):
+        max_optimization_threads = QDRANT_MAX_OPTIMIZATION_THREADS
+        if max_optimization_threads is not None:
+            max_optimization_threads = int(max_optimization_threads)
         cls.client.update_collection(
             collection_name=QDRANT_COLLECTION_NAME,
             optimizer_config=OptimizersConfigDiff(
-                # indexing_threshold=10_000,
-                max_optimization_threads=1,
+                max_optimization_threads=max_optimization_threads,
             ),
         )
-
         cls.wait_collection_green()
         return {}
 


### PR DESCRIPTION
This pull request introduces enhancements to the Qdrant client configuration on issues observed on large vector count ( > 40M ). The key changes include:

1. **Max Optimization Threads**: 
    - Added the ability to specify the `max_optimization_threads` parameter within the `post_upload()` method, enabling better control over resource utilization during optimization tasks. By looking at the actual usage of qdrant cloud instances during ingestion and indexing i could see that we were not using the entire deployment VCPUs. Adding the ability control the ammount of optimization threads should give us better usage. By default it will follow qdrant's Optimizer config base model ("If null - have no limit and choose dynamically to saturate CPU")
    
confirmation that indeed this change is effective, using a 1M vector sample dataset :

"None" - meaning no limit and choose dynamically to saturate CPU 
```
1000000it [00:26, 38223.74it/s]
Upload time: 26.269824364921078
Total import time: 36.38025348598603
```    
    
QDRANT_MAX_OPTIMIZATION_THREADS=1 - The current value of master
```
1000000it [00:26, 37504.10it/s]
Upload time: 26.770209033973515
Total import time: 76.93960217398126

```    

2. **Exponential Backoff**:
    - Implemented an exponential backoff mechanism to handle retries, improving robustness and error handling during the recreate_collection operation ( Fixes #162 )
