### PR TITLE
Cherry picking some milvus improvemens. Updated milvus client to include backoff strategy on ingestion. Added extra configurations to ease remote benchmark run.

### DIFF
--- a/engine/clients/milvus/__init__.py
+++ b/engine/clients/milvus/__init__.py
@@ -1,9 +1,3 @@
 from engine.clients.milvus.configure import MilvusConfigurator
 from engine.clients.milvus.search import MilvusSearcher
 from engine.clients.milvus.upload import MilvusUploader
-
-__all__ = [
-    "MilvusConfigurator",
-    "MilvusSearcher",
-    "MilvusUploader",
-]

--- a/engine/clients/milvus/config.py
+++ b/engine/clients/milvus/config.py
@@ -1,10 +1,13 @@
-from pymilvus import DataType
-
+from pymilvus import DataType, connections
+import os
 from engine.base_client.distances import Distance
 
 MILVUS_COLLECTION_NAME = "Benchmark"
 MILVUS_DEFAULT_ALIAS = "bench"
 MILVUS_DEFAULT_PORT = "19530"
+MILVUS_PASS = os.getenv("MILVUS_PASS", "")
+MILVUS_USER = os.getenv("MILVUS_USER", "")
+MILVUS_PORT = os.getenv("MILVUS_PORT", MILVUS_DEFAULT_PORT)
 
 DISTANCE_MAPPING = {
     Distance.L2: "L2",
@@ -23,5 +26,23 @@ DTYPE_DEFAULT = {
     DataType.INT64: 0,
     DataType.VARCHAR: "---MILVUS DOES NOT ACCEPT EMPTY STRINGS---",
     DataType.FLOAT: 0.0,
-    DataType.DOUBLE: 0.0,
 }
+
+
+def get_milvus_client(connection_params: dict, host: str, alias: str):
+    h = ""
+    uri = ""
+    if host.startswith("http"):
+        uri = host
+    else:
+        h = host
+    client = connections.connect(
+        alias=alias,
+        host=h,
+        uri=uri,
+        port=MILVUS_PORT,
+        user=MILVUS_USER,
+        password=MILVUS_PASS,
+        **connection_params
+    )
+    return client

--- a/engine/clients/milvus/configure.py
+++ b/engine/clients/milvus/configure.py
@@ -17,7 +17,7 @@ from engine.clients.milvus.config import (
     DTYPE_EXTRAS,
     MILVUS_COLLECTION_NAME,
     MILVUS_DEFAULT_ALIAS,
-    MILVUS_DEFAULT_PORT,
+    get_milvus_client,
 )
 
 
@@ -32,20 +32,18 @@ class MilvusConfigurator(BaseConfigurator):
 
     def __init__(self, host, collection_params: dict, connection_params: dict):
         super().__init__(host, collection_params, connection_params)
-        self.client = connections.connect(
-            alias=MILVUS_DEFAULT_ALIAS,
-            host=host,
-            port=str(connection_params.get("port", MILVUS_DEFAULT_PORT)),
-            **connection_params,
-        )
+        self.client = get_milvus_client(connection_params, host, MILVUS_DEFAULT_ALIAS)
         print("established connection")
 
     def clean(self):
-        try:
+        if utility.has_collection(MILVUS_COLLECTION_NAME, using=MILVUS_DEFAULT_ALIAS):
+            print("dropping collection named {MILVUS_COLLECTION_NAME}...")
             utility.drop_collection(MILVUS_COLLECTION_NAME, using=MILVUS_DEFAULT_ALIAS)
+            print("dropped collection named {MILVUS_COLLECTION_NAME}...")
+        assert (
             utility.has_collection(MILVUS_COLLECTION_NAME, using=MILVUS_DEFAULT_ALIAS)
-        except MilvusException:
-            pass
+            is False
+        )
 
     def recreate(self, dataset: Dataset, collection_params):
         idx = FieldSchema(

--- a/experiments/configurations/milvus-single-node.json
+++ b/experiments/configurations/milvus-single-node.json
@@ -5,10 +5,21 @@
     "connection_params": {},
     "collection_params": {},
     "search_params": [
-      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
-      { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
     ],
     "upload_params": { "parallel": 16, "index_params": { "efConstruction": 100, "M": 16 } }
+  },
+  {
+    "name": "milvus-m-16-ef-64",
+    "engine": "milvus",
+    "connection_params": {},
+    "collection_params": {},
+    "search_params": [
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
+    ],
+    "upload_params": { "parallel": 16, "index_params": { "efConstruction": 64, "M": 16 } }
   },
   {
     "name": "milvus-m-16-ef-128",
@@ -16,8 +27,8 @@
     "connection_params": {},
     "collection_params": {},
     "search_params": [
-      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
-      { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
     ],
     "upload_params": { "parallel": 16, "index_params": { "efConstruction": 128, "M": 16 } }
   },
@@ -27,8 +38,8 @@
     "connection_params": {},
     "collection_params": {},
     "search_params": [
-      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
-      { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
     ],
     "upload_params": { "parallel": 16, "index_params": { "efConstruction": 128, "M": 32 } }
   },
@@ -38,8 +49,8 @@
     "connection_params": {},
     "collection_params": {},
     "search_params": [
-      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
-      { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
     ],
     "upload_params": { "parallel": 16, "index_params": { "efConstruction": 256, "M": 32 } }
   },
@@ -49,8 +60,8 @@
     "connection_params": {},
     "collection_params": {},
     "search_params": [
-      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
-      { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
     ],
     "upload_params": { "parallel": 16, "index_params": { "efConstruction": 512, "M": 32 } }
   },
@@ -60,8 +71,8 @@
     "connection_params": {},
     "collection_params": {},
     "search_params": [
-      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
-      { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
     ],
     "upload_params": { "parallel": 16, "index_params": { "efConstruction": 256, "M": 64 } }
   },
@@ -71,8 +82,8 @@
     "connection_params": {},
     "collection_params": {},
     "search_params": [
-      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
-      { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
+      { "parallel": 1, "params": { "ef": 64 } }, { "parallel": 1, "params": { "ef": 128 } }, { "parallel": 1, "params": { "ef": 256 } }, { "parallel": 1, "params": { "ef": 512 } },
+      { "parallel": 100, "params": { "ef": 64 } }, { "parallel": 100, "params": { "ef": 128 } }, { "parallel": 100, "params": { "ef": 256 } }, { "parallel": 100, "params": { "ef": 512 } }
     ],
     "upload_params": { "parallel": 16, "index_params": { "efConstruction": 512, "M": 64 } }
   }


### PR DESCRIPTION
Fixes #54 
Furthermore, it also eases the process of running the milvus benchmark against remote hosts (like zilliz cloud deployments, or other SW deployments ). 

This has been used on our benchmarks, and was part of a bigger work in https://github.com/redis-performance/vector-db-benchmark.

Example of running targeting a zilliz cloud cluster:

```
MILVUS_USER="db_admin" \
MILVUS_PASS="<...>" \
MILVUS_PORT=<zilliz port> \
          python3 run.py  --engines milvus-m-* --datasets gist-960-euclidean \
                          --host https://<endpoint info>.zillizcloud.com:<zilliz port>
```
