### PR TITLE
Fix opensearch query parser

### DIFF
--- a/datasets/datasets.json
+++ b/datasets/datasets.json
@@ -138,7 +138,8 @@
     "schema": {
       "update_date_ts": "int",
       "labels": "keyword",
-      "submitter": "keyword"
+      "submitter": "keyword",
+      "id": "keyword"
     }
   },
     {

--- a/engine/clients/opensearch/parser.py
+++ b/engine/clients/opensearch/parser.py
@@ -25,7 +25,8 @@ class OpenSearchConditionParser(BaseConditionParser):
         lte: Optional[FieldValue],
         gte: Optional[FieldValue],
     ) -> Any:
-        return {"range": {field_name: {"lt": lt, "gt": gt, "lte": lte, "gte": gte}}}
+        field_filters = {k: v for k, v in {"lt": lt, "gt": gt, "lte": lte, "gte": gte}.items() if v is not None}
+        return {"range": {field_name: field_filters}}
 
     def build_geo_filter(
         self, field_name: str, lat: float, lon: float, radius: float

--- a/engine/clients/opensearch/parser.py
+++ b/engine/clients/opensearch/parser.py
@@ -25,7 +25,11 @@ class OpenSearchConditionParser(BaseConditionParser):
         lte: Optional[FieldValue],
         gte: Optional[FieldValue],
     ) -> Any:
-        field_filters = {k: v for k, v in {"lt": lt, "gt": gt, "lte": lte, "gte": gte}.items() if v is not None}
+        field_filters = {
+            k: v
+            for k, v in {"lt": lt, "gt": gt, "lte": lte, "gte": gte}.items()
+            if v is not None
+        }
         return {"range": {field_name: field_filters}}
 
     def build_geo_filter(


### PR DESCRIPTION
Also specify schema for id in arxiv-titles-384-angular filters dataset. This is needed as default mapping created by opensearch takes the type as float, but in the dataset we also have string.
This leads to 99% precision on the test dataset with opensearch.

```
{
  "params": {
    "dataset": "arxiv-titles-384-angular-filters",
    "experiment": "opensearch-default",
    "engine": "opensearch",
    "parallel": 10,
    "config": {
      "knn.algo_param.ef_search": 128
    }
  },
  "results": {
    "total_time": 391.3466711850051,
    "mean_time": 0.37053632343088827,
    "mean_precisions": 0.98962,
    "std_time": 0.3485163122349799,
    "min_time": 0.04950378900684882,
    "max_time": 3.548553360000369,
    "rps": 25.552791773390613,
    "p95_time": 1.0473700279486362,
    "p99_time": 1.4396829416653787
  }
}
```

Fixes #171