### PR TITLE
Allow CI to force clear previously running resources if required

### DIFF
--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -24,11 +24,15 @@ if [[ -z "$PRIVATE_IP_OF_THE_SERVER" ]]; then
   exit 1
 fi
 
+docker container rm -f ci-benchmark-upload || true
+docker container rm -f ci-benchmark-search || true
+
 docker rmi --force qdrant/vector-db-benchmark:latest || true
 
 docker run \
   --rm \
   -it \
+  --name ci-benchmark-upload \
   -v "$HOME/results:/code/results" \
   qdrant/vector-db-benchmark:latest \
   python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search
@@ -36,6 +40,7 @@ docker run \
 docker run \
   --rm \
   -it \
+  --name ci-benchmark-search \
   -v "$HOME/results:/code/results" \
   qdrant/vector-db-benchmark:latest \
   python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload

--- a/tools/run_server_container.sh
+++ b/tools/run_server_container.sh
@@ -34,7 +34,7 @@ if [[ ${QDRANT_VERSION} == docker/* ]] || [[ ${QDRANT_VERSION} == ghcr/* ]]; the
         CONTAINER_REGISTRY='ghcr.io'
     fi
 
-    DOCKER_COMPOSE="export QDRANT_VERSION=${QDRANT_VERSION}; export CONTAINER_REGISTRY=${CONTAINER_REGISTRY}; docker compose down; pkill qdrant ; docker rmi ${CONTAINER_REGISTRY}/qdrant/qdrant:${QDRANT_VERSION} || true ; docker compose up -d; docker container ls"
+    DOCKER_COMPOSE="export QDRANT_VERSION=${QDRANT_VERSION}; export CONTAINER_REGISTRY=${CONTAINER_REGISTRY}; docker compose down; pkill qdrant; docker rm -f qdrant-continuous || true; docker rmi -f ${CONTAINER_REGISTRY}/qdrant/qdrant:${QDRANT_VERSION} || true ; docker compose up -d; docker container ls -a"
     ssh -t  -o ServerAliveInterval=60 -o ServerAliveCountMax=3 "${SERVER_USERNAME}@${IP_OF_THE_SERVER}" "cd ./projects/vector-db-benchmark/engine/servers/${CONTAINER_NAME} ; $DOCKER_COMPOSE"
 else
     echo "Error: unknown version ${QDRANT_VERSION}. Version name should start with 'docker/' or 'ghcr/'"


### PR DESCRIPTION
CI benches were failing. I found the following errors from [the logs](https://github.com/qdrant/vector-db-benchmark/actions/runs/10287664428/job/28471248469):

```
Error response from daemon: conflict: unable to remove repository reference "docker.io/qdrant/qdrant:master" (must force) - container 40054a4e5693 is using its referenced image 3d4537be4e7c

Error response from daemon: Conflict. The container name "/qdrant-continuous" is already in use by container "40054a4e5693eda6b6597fc6f247ad365c5be985a7d545e3084c34b994ebac68". You have to remove (or rename) that container to be able to reuse that name.
```

Also, on sshing into the machine I found that sometimes 2 vector-db-benchmark containers are running if the 1st workflow is cancelled. This isn't ideal for perf benchmarking and should be avoided.

So we should clear existing resources before running CI workflow. 