### PR TITLE
fix: pgvector and_subfilter

### DIFF
--- a/engine/clients/pgvector/parser.py
+++ b/engine/clients/pgvector/parser.py
@@ -18,7 +18,7 @@ class PgVectorConditionParser(BaseConditionParser):
         return " AND ".join(clauses)
 
     def build_exact_match_filter(self, field_name: str, value: FieldValue) -> Any:
-        raise f"{field_name} == {json.dumps(value)}"
+        return f"{field_name} == {json.dumps(value)}"
 
     def build_range_filter(
         self,

--- a/engine/clients/pgvector/parser.py
+++ b/engine/clients/pgvector/parser.py
@@ -13,7 +13,7 @@ class PgVectorConditionParser(BaseConditionParser):
         if or_subfilters is not None and len(or_subfilters) > 0:
             clauses.append(f"( {' OR '.join(or_subfilters)} )")
         if and_subfilters is not None and len(and_subfilters) > 0:
-            clauses.append(f"( {' AND '.join(or_subfilters)} )")
+            clauses.append(f"( {' AND '.join(and_subfilters)} )")
 
         return " AND ".join(clauses)
 


### PR DESCRIPTION
Pgvector client does not use proposer parameter in condiction builder for and clauses.
Fixes : https://github.com/qdrant/vector-db-benchmark/issues/194