### PR TITLE
Add benchmark on collection load time

### DIFF
--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -8,128 +8,128 @@ on:
     - cron: "0 */4 * * *"
 
 jobs:
-#  runBenchmark:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Benches
-#        id: benches
-#        run: |
-#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#            bash -x tools/setup_ci.sh
-#
-#            declare -A DATASET_TO_ENGINE
-#            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
-#            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
-#            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
-#            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
-#
-#            set +e
-#
-#            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
-#              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
-#              export DATASETS=$dataset
-#
-#              # Benchmark the dev branch:
-#              export QDRANT_VERSION=ghcr/dev
-#              timeout 30m bash -x tools/run_ci.sh
-#
-#              # Benchmark the master branch:
-#              export QDRANT_VERSION=docker/master
-#              timeout 30m bash -x tools/run_ci.sh
-#            done
-#
-#            set -e
-#      - name: Fail job if any of the benches failed
-#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-#        run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-#  runTenantsBenchmark:
-#    runs-on: ubuntu-latest
-#    needs: runBenchmark
-#    if: ${{ always() }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Benches
-#        id: benches
-#        run: |
-#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#            bash -x tools/setup_ci.sh
-#
-#            set +e
-#
-#            # Benchmark filtered search by tenants with mem limitation
-#
-#            export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
-#            export DATASETS="random-768-100-tenants"
-#            export BENCHMARK_STRATEGY="tenants"
-#            export CONTAINER_MEM_LIMIT=160mb
-#
-#            # Benchmark the dev branch:
-#            export QDRANT_VERSION=ghcr/dev
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            # Benchmark the master branch:
-#            export QDRANT_VERSION=docker/master
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            set -e
-#      - name: Fail job if any of the benches failed
-#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-#        run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI tenants benchmarks run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI tenants benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runBenchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            bash -x tools/setup_ci.sh
+
+            declare -A DATASET_TO_ENGINE
+            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
+            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
+            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
+            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
+
+            set +e
+
+            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
+              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
+              export DATASETS=$dataset
+
+              # Benchmark the dev branch:
+              export QDRANT_VERSION=ghcr/dev
+              timeout 30m bash -x tools/run_ci.sh
+
+              # Benchmark the master branch:
+              export QDRANT_VERSION=docker/master
+              timeout 30m bash -x tools/run_ci.sh
+            done
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runTenantsBenchmark:
+    runs-on: ubuntu-latest
+    needs: runBenchmark
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            bash -x tools/setup_ci.sh
+
+            set +e
+
+            # Benchmark filtered search by tenants with mem limitation
+
+            export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
+            export DATASETS="random-768-100-tenants"
+            export BENCHMARK_STRATEGY="tenants"
+            export CONTAINER_MEM_LIMIT=160mb
+
+            # Benchmark the dev branch:
+            export QDRANT_VERSION=ghcr/dev
+            timeout 30m bash -x tools/run_ci.sh
+
+            # Benchmark the master branch:
+            export QDRANT_VERSION=docker/master
+            timeout 30m bash -x tools/run_ci.sh
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI tenants benchmarks run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI tenants benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   runLoadTimeBenchmark:
     runs-on: ubuntu-latest
-#    needs: runTenantsBenchmark
-#    if: ${{ always() }}
+    needs: runTenantsBenchmark
+    if: ${{ always() }}
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
@@ -163,23 +163,23 @@ jobs:
       - name: Fail job if any of the benches failed
         if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
         run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI tenants benchmarks run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI tenants benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI tenants benchmarks run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI tenants benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -8,8 +8,128 @@ on:
     - cron: "0 */4 * * *"
 
 jobs:
-  runBenchmark:
+#  runBenchmark:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: webfactory/ssh-agent@v0.8.0
+#        with:
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#      - name: Benches
+#        id: benches
+#        run: |
+#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+#            bash -x tools/setup_ci.sh
+#
+#            declare -A DATASET_TO_ENGINE
+#            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
+#            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
+#            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
+#            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
+#
+#            set +e
+#
+#            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
+#              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
+#              export DATASETS=$dataset
+#
+#              # Benchmark the dev branch:
+#              export QDRANT_VERSION=ghcr/dev
+#              timeout 30m bash -x tools/run_ci.sh
+#
+#              # Benchmark the master branch:
+#              export QDRANT_VERSION=docker/master
+#              timeout 30m bash -x tools/run_ci.sh
+#            done
+#
+#            set -e
+#      - name: Fail job if any of the benches failed
+#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+#        run: exit 1
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#  runTenantsBenchmark:
+#    runs-on: ubuntu-latest
+#    needs: runBenchmark
+#    if: ${{ always() }}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: webfactory/ssh-agent@v0.8.0
+#        with:
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#      - name: Benches
+#        id: benches
+#        run: |
+#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+#            bash -x tools/setup_ci.sh
+#
+#            set +e
+#
+#            # Benchmark filtered search by tenants with mem limitation
+#
+#            export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
+#            export DATASETS="random-768-100-tenants"
+#            export BENCHMARK_STRATEGY="tenants"
+#            export CONTAINER_MEM_LIMIT=160mb
+#
+#            # Benchmark the dev branch:
+#            export QDRANT_VERSION=ghcr/dev
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            # Benchmark the master branch:
+#            export QDRANT_VERSION=docker/master
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            set -e
+#      - name: Fail job if any of the benches failed
+#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+#        run: exit 1
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI tenants benchmarks run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI tenants benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runLoadTimeBenchmark:
     runs-on: ubuntu-latest
+#    needs: runTenantsBenchmark
+#    if: ${{ always() }}
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
@@ -23,76 +143,14 @@ jobs:
             export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
             bash -x tools/setup_ci.sh
 
-            declare -A DATASET_TO_ENGINE
-            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
-            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
-            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
-            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
-
             set +e
 
-            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
-              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
-              export DATASETS=$dataset
-
-              # Benchmark the dev branch:
-              export QDRANT_VERSION=ghcr/dev
-              timeout 30m bash -x tools/run_ci.sh
-
-              # Benchmark the master branch:
-              export QDRANT_VERSION=docker/master
-              timeout 30m bash -x tools/run_ci.sh
-            done
-
-            set -e
-      - name: Fail job if any of the benches failed
-        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-        run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  runTenantsBenchmark:
-    runs-on: ubuntu-latest
-    needs: runBenchmark
-    if: ${{ always() }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Benches
-        id: benches
-        run: |
-            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-            bash -x tools/setup_ci.sh
-
-            set +e
-
-            # Benchmark filtered search by tenants with mem limitation
+            # Benchmark collection load time
 
             export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
             export DATASETS="random-768-100-tenants"
-            export CONTAINER_MEM_LIMIT=160mb
-
+            export BENCHMARK_STRATEGY="collection-reload"
+          
             # Benchmark the dev branch:
             export QDRANT_VERSION=ghcr/dev
             timeout 30m bash -x tools/run_ci.sh
@@ -105,23 +163,23 @@ jobs:
       - name: Fail job if any of the benches failed
         if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
         run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI tenants benchmarks run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI tenants benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI tenants benchmarks run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI tenants benchmarks failed because of ${{ steps.benches.outputs.failed }}.\nView the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -150,7 +150,7 @@ jobs:
             export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
             export DATASETS="random-768-100-tenants"
             export BENCHMARK_STRATEGY="collection-reload"
-          
+
             # Benchmark the dev branch:
             export QDRANT_VERSION=ghcr/dev
             timeout 30m bash -x tools/run_ci.sh

--- a/tools/qdrant_collect_stats.sh
+++ b/tools/qdrant_collect_stats.sh
@@ -28,3 +28,7 @@ echo "$RSS_ANON_MEMORY_USAGE" > results/rss-anon-memory-usage-"${CURRENT_DATE}".
 ROOT_API_RESPONSE=$(ssh -t "${SERVER_USERNAME}@${IP_OF_THE_SERVER}" "curl -s http://localhost:6333/")
 
 echo "$ROOT_API_RESPONSE" > results/root-api-"${CURRENT_DATE}".json
+
+TELEMETRY_API_RESPONSE=$(ssh -t "${SERVER_USERNAME}@${IP_OF_THE_SERVER}" "curl -s http://localhost:6333/telemetry?details_level=10")
+
+echo "$TELEMETRY_API_RESPONSE" > results/telemetry-api-"${CURRENT_DATE}".json

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -18,6 +18,8 @@ trap 'handle_term' TERM
 
 # Script, that runs benchmark within the GitHub Actions CI environment
 
+BENCHMARK_STRATEGY=${BENCHMARK_STRATEGY:-"default"}
+
 SCRIPT=$(realpath "$0")
 SCRIPT_PATH=$(dirname "$SCRIPT")
 
@@ -30,5 +32,9 @@ export UPLOAD_RESULTS_FILE=$(ls -t results/*-upload-*.json | head -n 1)
 export VM_RSS_MEMORY_USAGE_FILE=$(ls -t results/vm-rss-memory-usage-*.txt | head -n 1)
 export RSS_ANON_MEMORY_USAGE_FILE=$(ls -t results/rss-anon-memory-usage-*.txt | head -n 1)
 export ROOT_API_RESPONSE_FILE=$(ls -t results/root-api-*.json | head -n 1)
+
+if [[ "$BENCHMARK_STRATEGY" == "collection-reload" ]]; then
+  export TELEMETRY_API_RESPONSE_FILE=$(ls -t results/telemetry-api-*.json | head -n 1)
+fi
 
 bash -x "${SCRIPT_PATH}/upload_results_postgres.sh"

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -27,14 +27,16 @@ bash -x "${SCRIPT_PATH}/run_remote_benchmark.sh"
 
 # Upload to postgres
 # -t sorts by modification time
-export SEARCH_RESULTS_FILE=$(ls -t results/*-search-*.json | head -n 1)
+if [[ "$BENCHMARK_STRATEGY" == "collection-reload" ]]; then
+  export TELEMETRY_API_RESPONSE_FILE=$(ls -t results/telemetry-api-*.json | head -n 1)
+else
+  # any other strategies are considered to have search results
+  export SEARCH_RESULTS_FILE=$(ls -t results/*-search-*.json | head -n 1)
+fi
+
 export UPLOAD_RESULTS_FILE=$(ls -t results/*-upload-*.json | head -n 1)
 export VM_RSS_MEMORY_USAGE_FILE=$(ls -t results/vm-rss-memory-usage-*.txt | head -n 1)
 export RSS_ANON_MEMORY_USAGE_FILE=$(ls -t results/rss-anon-memory-usage-*.txt | head -n 1)
 export ROOT_API_RESPONSE_FILE=$(ls -t results/root-api-*.json | head -n 1)
-
-if [[ "$BENCHMARK_STRATEGY" == "collection-reload" ]]; then
-  export TELEMETRY_API_RESPONSE_FILE=$(ls -t results/telemetry-api-*.json | head -n 1)
-fi
 
 bash -x "${SCRIPT_PATH}/upload_results_postgres.sh"

--- a/tools/run_remote_benchmark.sh
+++ b/tools/run_remote_benchmark.sh
@@ -31,11 +31,14 @@ trap 'cleanup' EXIT
 #SERVER_NAME=$BENCH_CLIENT_NAME SERVER_TYPE='cpx11' bash -x "${SCRIPT_PATH}/${CLOUD_NAME}/create_and_install.sh"
 #wait $SERVER_CREATION_PID
 
+BENCHMARK_STRATEGY=${BENCHMARK_STRATEGY:-"default"}
+
 SERVER_NAME=$BENCH_SERVER_NAME bash -x "${SCRIPT_PATH}/${CLOUD_NAME}/check_ssh_connection.sh"
 SERVER_NAME=$BENCH_CLIENT_NAME bash -x "${SCRIPT_PATH}/${CLOUD_NAME}/check_ssh_connection.sh"
 
-if [[ -z "${CONTAINER_MEM_LIMIT:-}" ]]; then
-  echo "CONTAINER_MEM_LIMIT is not set, run without memory limit"
+case "$BENCHMARK_STRATEGY" in
+  "default")
+  echo "Default benchmark, no volume, no memory limit"
 
   SERVER_CONTAINER_NAME=${SERVER_CONTAINER_NAME:-"qdrant-continuous-benchmarks"}
 
@@ -44,9 +47,14 @@ if [[ -z "${CONTAINER_MEM_LIMIT:-}" ]]; then
   bash -x "${SCRIPT_PATH}/run_client_script.sh"
 
   bash -x "${SCRIPT_PATH}/qdrant_collect_stats.sh" "$SERVER_CONTAINER_NAME"
+  ;;
+  "tenants")
+  if [[ -z "${CONTAINER_MEM_LIMIT:-}" ]]; then
+    echo "Tenants benchmark, but CONTAINER_MEM_LIMIT is not set!"
+    exit 2
+  fi
 
-else
-  echo "CONTAINER_MEM_LIMIT is set, run search with memory limit: ${CONTAINER_MEM_LIMIT}"
+  echo "Tenants benchmark, run search with memory limit: ${CONTAINER_MEM_LIMIT}"
 
   SERVER_CONTAINER_NAME=${SERVER_CONTAINER_NAME:-"qdrant-continuous-benchmarks-with-volume"}
 
@@ -59,6 +67,24 @@ else
   bash -x "${SCRIPT_PATH}/run_client_script.sh" "search"
 
   bash -x "${SCRIPT_PATH}/qdrant_collect_stats.sh" "$SERVER_CONTAINER_NAME"
+  ;;
 
-fi
+  "collection-reload")
+  echo "Collection load time benchmark"
 
+  SERVER_CONTAINER_NAME=${SERVER_CONTAINER_NAME:-"qdrant-continuous-benchmarks-with-volume"}
+
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME"
+
+  bash -x "${SCRIPT_PATH}/run_client_script.sh" "upload"
+
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME" "25Gb" "continue"
+
+  bash -x "${SCRIPT_PATH}/qdrant_collect_stats.sh" "$SERVER_CONTAINER_NAME"
+  ;;
+
+  *)
+    echo "Invalid BENCHMARK_STRATEGY value: $BENCHMARK_STRATEGY"
+    exit 1
+    ;;
+esac

--- a/tools/upload_results_postgres.sh
+++ b/tools/upload_results_postgres.sh
@@ -19,6 +19,7 @@
 # 	p99_time real,
 # 	vm_rss_mem real,
 # 	rss_anon_mem real
+# 	collection_load_time_ms real
 # );
 
 SEARCH_RESULTS_FILE=${SEARCH_RESULTS_FILE:-""}
@@ -26,6 +27,7 @@ UPLOAD_RESULTS_FILE=${UPLOAD_RESULTS_FILE:-""}
 VM_RSS_MEMORY_USAGE_FILE=${VM_RSS_MEMORY_USAGE_FILE:-""}
 RSS_ANON_MEMORY_USAGE_FILE=${RSS_ANON_MEMORY_USAGE_FILE:-""}
 ROOT_API_RESPONSE_FILE=${ROOT_API_RESPONSE_FILE:-""}
+TELEMETRY_API_RESPONSE_FILE=${TELEMETRY_API_RESPONSE_FILE:-""}
 POSTGRES_TABLE=${POSTGRES_TABLE:-"benchmark"}
 
 QDRANT_VERSION=${QDRANT_VERSION:-"dev"}
@@ -58,6 +60,13 @@ if [[ -z "$ROOT_API_RESPONSE_FILE" ]]; then
   exit 1
 fi
 
+COLLECTION_LOAD_TIME=NULL
+if [[ -z "$TELEMETRY_API_RESPONSE_FILE" ]]; then
+  echo "Skip telemetry results"
+else
+  COLLECTION_LOAD_TIME=$(jq -r '.result.collections.collections[] | select(.id == "benchmark") | .init_time_ms' "$TELEMETRY_API_RESPONSE_FILE")
+fi
+
 RPS=$(jq -r '.results.rps' "$SEARCH_RESULTS_FILE")
 MEAN_PRECISIONS=$(jq -r '.results.mean_precisions' "$SEARCH_RESULTS_FILE")
 P95_TIME=$(jq -r '.results.p95_time' "$SEARCH_RESULTS_FILE")
@@ -74,8 +83,8 @@ QDRANT_COMMIT=$(jq -r '.commit' "$ROOT_API_RESPONSE_FILE")
 MEASURE_TIMESTAMP=${MEASURE_TIMESTAMP:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
 
 
-docker run --rm jbergknoff/postgresql-client "postgresql://qdrant:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/postgres" -c "
-INSERT INTO ${POSTGRES_TABLE} (engine, branch, commit, dataset, measure_timestamp, upload_time, indexing_time, rps, mean_precisions, p95_time, p99_time, vm_rss_mem, rss_anon_mem)
-VALUES ('qdrant-ci', '${QDRANT_VERSION}', '${QDRANT_COMMIT}', '${DATASETS}', '${MEASURE_TIMESTAMP}', ${UPLOAD_TIME}, ${INDEXING_TIME}, ${RPS}, ${MEAN_PRECISIONS}, ${P95_TIME}, ${P99_TIME}, ${VM_RSS_MEMORY_USAGE}, ${RSS_ANON_MEMORY_USAGE});
+docker run --name "vector-db" --rm jbergknoff/postgresql-client "postgresql://qdrant:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/postgres" -c "
+INSERT INTO ${POSTGRES_TABLE} (engine, branch, commit, dataset, measure_timestamp, upload_time, indexing_time, rps, mean_precisions, p95_time, p99_time, vm_rss_mem, rss_anon_mem, collection_load_time_ms)
+VALUES ('qdrant-ci', '${QDRANT_VERSION}', '${QDRANT_COMMIT}', '${DATASETS}', '${MEASURE_TIMESTAMP}', ${UPLOAD_TIME}, ${INDEXING_TIME}, ${RPS}, ${MEAN_PRECISIONS}, ${P95_TIME}, ${P99_TIME}, ${VM_RSS_MEMORY_USAGE}, ${RSS_ANON_MEMORY_USAGE}, ${COLLECTION_LOAD_TIME});
 "
 


### PR DESCRIPTION
* Add new column `collection_load_time_ms` to benchmark table
* Introduce BENCHMARK_STRATEGY variable to control the flow of the workflow (default | tenants | collection-load)
* Only push telemetry data into Postgres if BENCHMARK_STRATEGY is set to `collection-load`

Right now the dataset under test is `random-768-100-tenants`