### PR TITLE
Allow parallel optimizations in Qdrant after uploading

### DIFF
--- a/engine/clients/qdrant/upload.py
+++ b/engine/clients/qdrant/upload.py
@@ -62,7 +62,8 @@ class QdrantUploader(BaseUploader):
             collection_name=QDRANT_COLLECTION_NAME,
             optimizer_config=OptimizersConfigDiff(
                 # indexing_threshold=10_000,
-                max_optimization_threads=1,
+                # Set to a high number to not apply limits, already limited by CPU budget
+                max_optimization_threads=100_000,
             ),
         )
 


### PR DESCRIPTION
The `max_optimization_threads` parameter is currently configured incorrectly after uploading, and this does not allow parallel optimizations.

This PR sets it to a high value so that we do use parallel optimizations as it'll likely result in better results. Note that setting such high limit is fine, because in practice we're still limited by CPU budget. We cannot set it back to `null` through this API.

On my machine with 24 CPUs I now see 3 parallel optimizations, rather than just 1. The indexing time is more than 2 times quicker.

Am I correct that the benchmark machine we used for the public results does not have more than 8 CPU cores? If we did have more cores, we should probably redo the benchmarks.