### PR TITLE
Add benchmark on parallel upload and search

### DIFF
--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -312,14 +312,14 @@ jobs:
             export DATASETS="laion-small-clip"
             export BENCHMARK_STRATEGY="parallel"
             export POSTGRES_TABLE="benchmark_parallel_search_upload"
-          
+
             # Benchmark the dev branch:
             export QDRANT_VERSION=ghcr/dev
             timeout 30m bash -x tools/run_ci.sh
 
             # Benchmark the master branch:
             export QDRANT_VERSION=docker/master
-            timeout 30m bash -x tools/run_ci.sh          
+            timeout 30m bash -x tools/run_ci.sh
 
             set -e
       - name: Fail job if any of the benches failed

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -286,3 +286,90 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  runParallelBenchmark:
+    runs-on: ubuntu-latest
+    needs: [ runLoadTimeBenchmark, runTenantsBenchmark ]
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            bash -x tools/setup_ci.sh
+
+            set +e
+
+            # Benchmark parallel search&upload
+
+            export ENGINE_NAME="qdrant-continuous-benchmark"
+            export DATASETS="laion-small-clip"
+            export BENCHMARK_STRATEGY="parallel"
+            export POSTGRES_TABLE="benchmark_parallel_search_upload"
+          
+            # Benchmark the dev branch:
+            export QDRANT_VERSION=ghcr/dev
+            timeout 30m bash -x tools/run_ci.sh
+
+            # Benchmark the master branch:
+            export QDRANT_VERSION=docker/master
+            timeout 30m bash -x tools/run_ci.sh          
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -8,288 +8,288 @@ on:
     - cron: "0 */4 * * *"
 
 jobs:
-#  runBenchmark:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Benches
-#        id: benches
-#        run: |
-#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#            bash -x tools/setup_ci.sh
-#
-#            declare -A DATASET_TO_ENGINE
-#            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
-#            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
-#            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
-#            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
-#
-#            set +e
-#
-#            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
-#              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
-#              export DATASETS=$dataset
-#
-#              # Benchmark the dev branch:
-#              export QDRANT_VERSION=ghcr/dev
-#              timeout 30m bash -x tools/run_ci.sh
-#
-#              # Benchmark the master branch:
-#              export QDRANT_VERSION=docker/master
-#              timeout 30m bash -x tools/run_ci.sh
-#            done
-#
-#            set -e
-#      - name: Fail job if any of the benches failed
-#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-#        run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-#  runTenantsBenchmark:
-#    runs-on: ubuntu-latest
-#    needs: runBenchmark
-#    if: ${{ always() }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Benches
-#        id: benches
-#        run: |
-#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#            bash -x tools/setup_ci.sh
-#
-#            set +e
-#
-#            # Benchmark filtered search by tenants with mem limitation
-#
-#            export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
-#            export DATASETS="random-768-100-tenants"
-#            export BENCHMARK_STRATEGY="tenants"
-#            export CONTAINER_MEM_LIMIT=160mb
-#
-#            # Benchmark the dev branch:
-#            export QDRANT_VERSION=ghcr/dev
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            # Benchmark the master branch:
-#            export QDRANT_VERSION=docker/master
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            set -e
-#      - name: Fail job if any of the benches failed
-#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-#        run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-#  runLoadTimeBenchmark:
-#    runs-on: ubuntu-latest
-#    needs: runBenchmark
-#    if: ${{ always() }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Benches
-#        id: benches
-#        run: |
-#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#            export SERVER_NAME="benchmark-server-3"
-#            bash -x tools/setup_ci.sh
-#
-#            set +e
-#
-#            # Benchmark collection load time
-#            export BENCHMARK_STRATEGY="collection-reload"
-#
-#            declare -A DATASET_TO_ENGINE
-#            declare -A DATASET_TO_URL
-#            DATASET_TO_ENGINE["all-payloads-default"]="qdrant-continuous-benchmark-snapshot"
-#            DATASET_TO_ENGINE["all-payloads-on-disk"]="qdrant-continuous-benchmark-snapshot"
-#            DATASET_TO_ENGINE["all-payloads-default-sparse"]="qdrant-continuous-benchmark-snapshot"
-#            DATASET_TO_ENGINE["all-payloads-on-disk-sparse"]="qdrant-continuous-benchmark-snapshot"
-#
-#            export STORAGE_URL="https://storage.googleapis.com/qdrant-benchmark-snapshots/all-payloads"
-#            DATASET_TO_URL["all-payloads-default"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-default.snapshot"
-#            DATASET_TO_URL["all-payloads-on-disk"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-on-disk.snapshot"
-#            DATASET_TO_URL["all-payloads-default-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-default.snapshot"
-#            DATASET_TO_URL["all-payloads-on-disk-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-on-disk.snapshot"
-#
-#            set +e
-#
-#            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
-#              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
-#              export DATASETS=$dataset
-#              export SNAPSHOT_URL=${DATASET_TO_URL[$dataset]}
-#
-#              # Benchmark the dev branch:
-#              export QDRANT_VERSION=ghcr/dev
-#              timeout 30m bash -x tools/run_ci.sh
-#
-#              # Benchmark the master branch:
-#              export QDRANT_VERSION=docker/master
-#              timeout 30m bash -x tools/run_ci.sh
-#            done
-#
-#            set -e
-#      - name: Fail job if any of the benches failed
-#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-#        run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks (runLoadTimeBenchmark) run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks (runLoadTimeBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runBenchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            bash -x tools/setup_ci.sh
 
-#    needs: [ runLoadTimeBenchmark, runTenantsBenchmark ]
+            declare -A DATASET_TO_ENGINE
+            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
+            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
+            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
+            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
+
+            set +e
+
+            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
+              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
+              export DATASETS=$dataset
+
+              # Benchmark the dev branch:
+              export QDRANT_VERSION=ghcr/dev
+              timeout 30m bash -x tools/run_ci.sh
+
+              # Benchmark the master branch:
+              export QDRANT_VERSION=docker/master
+              timeout 30m bash -x tools/run_ci.sh
+            done
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runTenantsBenchmark:
+    runs-on: ubuntu-latest
+    needs: runBenchmark
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            bash -x tools/setup_ci.sh
+
+            set +e
+
+            # Benchmark filtered search by tenants with mem limitation
+
+            export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
+            export DATASETS="random-768-100-tenants"
+            export BENCHMARK_STRATEGY="tenants"
+            export CONTAINER_MEM_LIMIT=160mb
+
+            # Benchmark the dev branch:
+            export QDRANT_VERSION=ghcr/dev
+            timeout 30m bash -x tools/run_ci.sh
+
+            # Benchmark the master branch:
+            export QDRANT_VERSION=docker/master
+            timeout 30m bash -x tools/run_ci.sh
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runLoadTimeBenchmark:
+    runs-on: ubuntu-latest
+    needs: runBenchmark
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            export SERVER_NAME="benchmark-server-3"
+            bash -x tools/setup_ci.sh
+
+            set +e
+
+            # Benchmark collection load time
+            export BENCHMARK_STRATEGY="collection-reload"
+
+            declare -A DATASET_TO_ENGINE
+            declare -A DATASET_TO_URL
+            DATASET_TO_ENGINE["all-payloads-default"]="qdrant-continuous-benchmark-snapshot"
+            DATASET_TO_ENGINE["all-payloads-on-disk"]="qdrant-continuous-benchmark-snapshot"
+            DATASET_TO_ENGINE["all-payloads-default-sparse"]="qdrant-continuous-benchmark-snapshot"
+            DATASET_TO_ENGINE["all-payloads-on-disk-sparse"]="qdrant-continuous-benchmark-snapshot"
+
+            export STORAGE_URL="https://storage.googleapis.com/qdrant-benchmark-snapshots/all-payloads"
+            DATASET_TO_URL["all-payloads-default"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-default.snapshot"
+            DATASET_TO_URL["all-payloads-on-disk"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-on-disk.snapshot"
+            DATASET_TO_URL["all-payloads-default-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-default.snapshot"
+            DATASET_TO_URL["all-payloads-on-disk-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-on-disk.snapshot"
+
+            set +e
+
+            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
+              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
+              export DATASETS=$dataset
+              export SNAPSHOT_URL=${DATASET_TO_URL[$dataset]}
+
+              # Benchmark the dev branch:
+              export QDRANT_VERSION=ghcr/dev
+              timeout 30m bash -x tools/run_ci.sh
+
+              # Benchmark the master branch:
+              export QDRANT_VERSION=docker/master
+              timeout 30m bash -x tools/run_ci.sh
+            done
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runLoadTimeBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runLoadTimeBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
   runParallelBenchmark:
     runs-on: ubuntu-latest
+    needs: [ runLoadTimeBenchmark, runTenantsBenchmark ]
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v3
@@ -325,51 +325,51 @@ jobs:
       - name: Fail job if any of the benches failed
         if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
         run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -8,288 +8,288 @@ on:
     - cron: "0 */4 * * *"
 
 jobs:
-  runBenchmark:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Benches
-        id: benches
-        run: |
-            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-            bash -x tools/setup_ci.sh
+#  runBenchmark:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: webfactory/ssh-agent@v0.8.0
+#        with:
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#      - name: Benches
+#        id: benches
+#        run: |
+#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+#            bash -x tools/setup_ci.sh
+#
+#            declare -A DATASET_TO_ENGINE
+#            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
+#            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
+#            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
+#            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
+#
+#            set +e
+#
+#            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
+#              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
+#              export DATASETS=$dataset
+#
+#              # Benchmark the dev branch:
+#              export QDRANT_VERSION=ghcr/dev
+#              timeout 30m bash -x tools/run_ci.sh
+#
+#              # Benchmark the master branch:
+#              export QDRANT_VERSION=docker/master
+#              timeout 30m bash -x tools/run_ci.sh
+#            done
+#
+#            set -e
+#      - name: Fail job if any of the benches failed
+#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+#        run: exit 1
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#  runTenantsBenchmark:
+#    runs-on: ubuntu-latest
+#    needs: runBenchmark
+#    if: ${{ always() }}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: webfactory/ssh-agent@v0.8.0
+#        with:
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#      - name: Benches
+#        id: benches
+#        run: |
+#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+#            bash -x tools/setup_ci.sh
+#
+#            set +e
+#
+#            # Benchmark filtered search by tenants with mem limitation
+#
+#            export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
+#            export DATASETS="random-768-100-tenants"
+#            export BENCHMARK_STRATEGY="tenants"
+#            export CONTAINER_MEM_LIMIT=160mb
+#
+#            # Benchmark the dev branch:
+#            export QDRANT_VERSION=ghcr/dev
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            # Benchmark the master branch:
+#            export QDRANT_VERSION=docker/master
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            set -e
+#      - name: Fail job if any of the benches failed
+#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+#        run: exit 1
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#  runLoadTimeBenchmark:
+#    runs-on: ubuntu-latest
+#    needs: runBenchmark
+#    if: ${{ always() }}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: webfactory/ssh-agent@v0.8.0
+#        with:
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#      - name: Benches
+#        id: benches
+#        run: |
+#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+#            export SERVER_NAME="benchmark-server-3"
+#            bash -x tools/setup_ci.sh
+#
+#            set +e
+#
+#            # Benchmark collection load time
+#            export BENCHMARK_STRATEGY="collection-reload"
+#
+#            declare -A DATASET_TO_ENGINE
+#            declare -A DATASET_TO_URL
+#            DATASET_TO_ENGINE["all-payloads-default"]="qdrant-continuous-benchmark-snapshot"
+#            DATASET_TO_ENGINE["all-payloads-on-disk"]="qdrant-continuous-benchmark-snapshot"
+#            DATASET_TO_ENGINE["all-payloads-default-sparse"]="qdrant-continuous-benchmark-snapshot"
+#            DATASET_TO_ENGINE["all-payloads-on-disk-sparse"]="qdrant-continuous-benchmark-snapshot"
+#
+#            export STORAGE_URL="https://storage.googleapis.com/qdrant-benchmark-snapshots/all-payloads"
+#            DATASET_TO_URL["all-payloads-default"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-default.snapshot"
+#            DATASET_TO_URL["all-payloads-on-disk"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-on-disk.snapshot"
+#            DATASET_TO_URL["all-payloads-default-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-default.snapshot"
+#            DATASET_TO_URL["all-payloads-on-disk-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-on-disk.snapshot"
+#
+#            set +e
+#
+#            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
+#              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
+#              export DATASETS=$dataset
+#              export SNAPSHOT_URL=${DATASET_TO_URL[$dataset]}
+#
+#              # Benchmark the dev branch:
+#              export QDRANT_VERSION=ghcr/dev
+#              timeout 30m bash -x tools/run_ci.sh
+#
+#              # Benchmark the master branch:
+#              export QDRANT_VERSION=docker/master
+#              timeout 30m bash -x tools/run_ci.sh
+#            done
+#
+#            set -e
+#      - name: Fail job if any of the benches failed
+#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+#        run: exit 1
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks (runLoadTimeBenchmark) run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks (runLoadTimeBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-            declare -A DATASET_TO_ENGINE
-            DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark"
-            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector"
-            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark"
-            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark"
-
-            set +e
-
-            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
-              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
-              export DATASETS=$dataset
-
-              # Benchmark the dev branch:
-              export QDRANT_VERSION=ghcr/dev
-              timeout 30m bash -x tools/run_ci.sh
-
-              # Benchmark the master branch:
-              export QDRANT_VERSION=docker/master
-              timeout 30m bash -x tools/run_ci.sh
-            done
-
-            set -e
-      - name: Fail job if any of the benches failed
-        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-        run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  runTenantsBenchmark:
-    runs-on: ubuntu-latest
-    needs: runBenchmark
-    if: ${{ always() }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Benches
-        id: benches
-        run: |
-            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-            bash -x tools/setup_ci.sh
-
-            set +e
-
-            # Benchmark filtered search by tenants with mem limitation
-
-            export ENGINE_NAME="qdrant-all-on-disk-scalar-q"
-            export DATASETS="random-768-100-tenants"
-            export BENCHMARK_STRATEGY="tenants"
-            export CONTAINER_MEM_LIMIT=160mb
-
-            # Benchmark the dev branch:
-            export QDRANT_VERSION=ghcr/dev
-            timeout 30m bash -x tools/run_ci.sh
-
-            # Benchmark the master branch:
-            export QDRANT_VERSION=docker/master
-            timeout 30m bash -x tools/run_ci.sh
-
-            set -e
-      - name: Fail job if any of the benches failed
-        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-        run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  runLoadTimeBenchmark:
-    runs-on: ubuntu-latest
-    needs: runBenchmark
-    if: ${{ always() }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Benches
-        id: benches
-        run: |
-            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-            export SERVER_NAME="benchmark-server-3"
-            bash -x tools/setup_ci.sh
-
-            set +e
-
-            # Benchmark collection load time
-            export BENCHMARK_STRATEGY="collection-reload"
-
-            declare -A DATASET_TO_ENGINE
-            declare -A DATASET_TO_URL
-            DATASET_TO_ENGINE["all-payloads-default"]="qdrant-continuous-benchmark-snapshot"
-            DATASET_TO_ENGINE["all-payloads-on-disk"]="qdrant-continuous-benchmark-snapshot"
-            DATASET_TO_ENGINE["all-payloads-default-sparse"]="qdrant-continuous-benchmark-snapshot"
-            DATASET_TO_ENGINE["all-payloads-on-disk-sparse"]="qdrant-continuous-benchmark-snapshot"
-
-            export STORAGE_URL="https://storage.googleapis.com/qdrant-benchmark-snapshots/all-payloads"
-            DATASET_TO_URL["all-payloads-default"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-default.snapshot"
-            DATASET_TO_URL["all-payloads-on-disk"]="${STORAGE_URL}/benchmark-all-payloads-500k-768-on-disk.snapshot"
-            DATASET_TO_URL["all-payloads-default-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-default.snapshot"
-            DATASET_TO_URL["all-payloads-on-disk-sparse"]="${STORAGE_URL}/benchmark-all-payloads-500k-sparse-on-disk.snapshot"
-
-            set +e
-
-            for dataset in "${!DATASET_TO_ENGINE[@]}"; do
-              export ENGINE_NAME=${DATASET_TO_ENGINE[$dataset]}
-              export DATASETS=$dataset
-              export SNAPSHOT_URL=${DATASET_TO_URL[$dataset]}
-
-              # Benchmark the dev branch:
-              export QDRANT_VERSION=ghcr/dev
-              timeout 30m bash -x tools/run_ci.sh
-
-              # Benchmark the master branch:
-              export QDRANT_VERSION=docker/master
-              timeout 30m bash -x tools/run_ci.sh
-            done
-
-            set -e
-      - name: Fail job if any of the benches failed
-        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-        run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks (runLoadTimeBenchmark) run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks (runLoadTimeBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
+#    needs: [ runLoadTimeBenchmark, runTenantsBenchmark ]
   runParallelBenchmark:
     runs-on: ubuntu-latest
-    needs: [ runLoadTimeBenchmark, runTenantsBenchmark ]
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v3
@@ -325,51 +325,51 @@ jobs:
       - name: Fail job if any of the benches failed
         if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
         run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/engine/base_client/client.py
+++ b/engine/base_client/client.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from benchmark import ROOT_DIR
 from benchmark.dataset import Dataset
@@ -84,6 +84,7 @@ class BaseClient:
         skip_upload: bool = False,
         skip_search: bool = False,
         skip_if_exists: bool = True,
+        skip_configure: Optional[bool] = False,
     ):
         execution_params = self.configurator.execution_params(
             distance=dataset.config.distance, vector_size=dataset.config.vector_size
@@ -101,8 +102,9 @@ class BaseClient:
                 return
 
         if not skip_upload:
-            print("Experiment stage: Configure")
-            self.configurator.configure(dataset)
+            if not skip_configure:
+                print("Experiment stage: Configure")
+                self.configurator.configure(dataset)
 
             print("Experiment stage: Upload")
             upload_stats = self.uploader.upload(

--- a/run.py
+++ b/run.py
@@ -58,7 +58,11 @@ def run(
 
                 with stopit.ThreadingTimeout(timeout) as tt:
                     client.run_experiment(
-                        dataset, skip_upload, skip_search, skip_if_exists, skip_configure
+                        dataset,
+                        skip_upload,
+                        skip_search,
+                        skip_if_exists,
+                        skip_configure,
                     )
                 client.delete_client()
 

--- a/run.py
+++ b/run.py
@@ -1,6 +1,6 @@
 import fnmatch
 import traceback
-from typing import List
+from typing import List, Optional
 
 import stopit
 import typer
@@ -23,6 +23,7 @@ def run(
     skip_if_exists: bool = False,
     exit_on_error: bool = True,
     timeout: float = 86400.0,
+    skip_configure: Optional[bool] = False,
 ):
     """
     Example:
@@ -57,7 +58,7 @@ def run(
 
                 with stopit.ThreadingTimeout(timeout) as tt:
                     client.run_experiment(
-                        dataset, skip_upload, skip_search, skip_if_exists
+                        dataset, skip_upload, skip_search, skip_if_exists, skip_configure
                     )
                 client.delete_client()
 

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -45,4 +45,9 @@ export VM_RSS_MEMORY_USAGE_FILE=$(ls -t results/vm-rss-memory-usage-*.txt | head
 export RSS_ANON_MEMORY_USAGE_FILE=$(ls -t results/rss-anon-memory-usage-*.txt | head -n 1)
 export ROOT_API_RESPONSE_FILE=$(ls -t results/root-api-*.json | head -n 1)
 
-bash -x "${SCRIPT_PATH}/upload_results_postgres.sh"
+if [[ "$BENCHMARK_STRATEGY" != "parallel" ]]; then
+  bash -x "${SCRIPT_PATH}/upload_results_postgres.sh"
+else
+  bash -x "${SCRIPT_PATH}/upload_parallel_results_postgres.sh"
+fi
+

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -39,6 +39,13 @@ else
   # any other strategies are considered to have search & upload results
   export SEARCH_RESULTS_FILE=$(ls -t results/*-search-*.json | head -n 1)
   export UPLOAD_RESULTS_FILE=$(ls -t results/*-upload-*.json | head -n 1)
+
+  if [[ "$BENCHMARK_STRATEGY" == "parallel" ]]; then
+    # parallel experiment produces 2 *-search-*.json files
+    # one for search during upsert and the other for search without upsert
+    # export the latter here
+    export NO_UPSERT_SEARCH_RESULT_FILE=$(ls -t results/*-search-*.json | sed -n 2p)
+  fi
 fi
 
 export VM_RSS_MEMORY_USAGE_FILE=$(ls -t results/vm-rss-memory-usage-*.txt | head -n 1)

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -52,9 +52,9 @@ export VM_RSS_MEMORY_USAGE_FILE=$(ls -t results/vm-rss-memory-usage-*.txt | head
 export RSS_ANON_MEMORY_USAGE_FILE=$(ls -t results/rss-anon-memory-usage-*.txt | head -n 1)
 export ROOT_API_RESPONSE_FILE=$(ls -t results/root-api-*.json | head -n 1)
 
-if [[ "$BENCHMARK_STRATEGY" != "parallel" ]]; then
-  bash -x "${SCRIPT_PATH}/upload_results_postgres.sh"
-else
+if [[ "$BENCHMARK_STRATEGY" == "parallel" ]]; then
   bash -x "${SCRIPT_PATH}/upload_parallel_results_postgres.sh"
+else
+  bash -x "${SCRIPT_PATH}/upload_results_postgres.sh"
 fi
 

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -41,10 +41,8 @@ else
   export UPLOAD_RESULTS_FILE=$(ls -t results/*-upload-*.json | head -n 1)
 
   if [[ "$BENCHMARK_STRATEGY" == "parallel" ]]; then
-    # parallel experiment produces 2 *-search-*.json files
-    # one for search during upsert and the other for search without upsert
-    # export the latter here
-    export NO_UPSERT_SEARCH_RESULT_FILE=$(ls -t results/*-search-*.json | sed -n 2p)
+    export PARALLEL_UPLOAD_RESULTS_FILE=$(ls -t results/parallel/*-upload-*.json | head -n 1)
+    export PARALLEL_SEARCH_RESULTS_FILE=$(ls -t results/parallel/*-search-*.json | head -n 1)
   fi
 fi
 

--- a/tools/run_client_script.sh
+++ b/tools/run_client_script.sh
@@ -52,20 +52,34 @@ fi
 
 echo "Gather experiment results..."
 result_files_arr=()
+result_parallel_files_arr=()
 
-if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "upload" ]] || [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
+if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "upload" ]]; then
   UPLOAD_RESULT_FILE=$(ssh "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "ls -t results/*-upload-*.json | head -n 1")
   result_files_arr+=("$UPLOAD_RESULT_FILE")
 fi
 
-if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "search" ]] || [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
+if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "search" ]]; then
   SEARCH_RESULT_FILE=$(ssh "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "ls -t results/*-search-*.json | head -n 1")
   result_files_arr+=("$SEARCH_RESULT_FILE")
 fi
 
+if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
+  UPLOAD_RESULT_FILE=$(ssh "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "ls -t results/parallel/*-upload-*.json | head -n 1")
+  result_parallel_files_arr+=("$UPLOAD_RESULT_FILE")
+
+  SEARCH_RESULT_FILE=$(ssh "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "ls -t results/parallel/*-search-*.json | head -n 1")
+  result_parallel_files_arr+=("$SEARCH_RESULT_FILE")
+fi
+
 mkdir -p results
+mkdir -p results/parallel
 
 for RESULT_FILE in "${result_files_arr[@]}"; do
     # -p preseves modification time, access time, and modes (but not change time)
     scp -p "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}:~/${RESULT_FILE}" "./results"
+done
+
+for RESULT_FILE in "${result_parallel_files_arr[@]}"; do
+    scp -p "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}:~/${RESULT_FILE}" "./results/parallel"
 done

--- a/tools/run_client_script.sh
+++ b/tools/run_client_script.sh
@@ -3,7 +3,7 @@
 PS4='ts=$(date "+%Y-%m-%dT%H:%M:%SZ") level=DEBUG line=$LINENO file=$BASH_SOURCE '
 set -euo pipefail
 
-# Possible values are: full|upload|search
+# Possible values are: full|upload|search|parallel|snapshot
 EXPERIMENT_MODE=${1:-"full"}
 
 CLOUD_NAME=${CLOUD_NAME:-"hetzner"}
@@ -53,12 +53,12 @@ fi
 echo "Gather experiment results..."
 result_files_arr=()
 
-if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "upload" ]]; then
+if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "upload" ]] || [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   UPLOAD_RESULT_FILE=$(ssh "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "ls -t results/*-upload-*.json | head -n 1")
   result_files_arr+=("$UPLOAD_RESULT_FILE")
 fi
 
-if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "search" ]]; then
+if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "search" ]] || [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   SEARCH_RESULT_FILE=$(ssh "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "ls -t results/*-search-*.json | head -n 1")
   result_files_arr+=("$SEARCH_RESULT_FILE")
 fi

--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -78,14 +78,14 @@ fi
 if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   echo "EXPERIMENT_MODE=$EXPERIMENT_MODE"
 
-  docker pull qdrant/vector-db-benchmark:latest
+#  docker pull qdrant/vector-db-benchmark:latest
 
   echo "Starting ci-benchmark-upload container"
   docker run \
     --rm \
     --name ci-benchmark-upload \
     -v "$HOME/results/parallel:/code/results" \
-    qdrant/vector-db-benchmark:latest \
+    vector-db-benchmark:el_latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search --skip-configure &
   UPLOAD_PID=$!
 
@@ -94,7 +94,7 @@ if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
     --rm \
     --name ci-benchmark-search \
     -v "$HOME/results/parallel:/code/results" \
-    qdrant/vector-db-benchmark:latest \
+    vector-db-benchmark:el_latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload &
   SEARCH_PID=$!
 

--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -78,14 +78,14 @@ fi
 if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   echo "EXPERIMENT_MODE=$EXPERIMENT_MODE"
 
-  docker pull qdrant/vector-db-benchmark:latest
+#  docker pull qdrant/vector-db-benchmark:latest
 
   echo "Starting ci-benchmark-upload container"
   docker run \
     --rm \
     --name ci-benchmark-upload \
     -v "$HOME/results:/code/results" \
-    qdrant/vector-db-benchmark:latest \
+    vector-db-benchmark:el_latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search --skip-configure &
   UPLOAD_PID=$!
 
@@ -94,7 +94,7 @@ if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
     --rm \
     --name ci-benchmark-search \
     -v "$HOME/results:/code/results" \
-    qdrant/vector-db-benchmark:latest \
+    vector-db-benchmark:el_latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload &
   SEARCH_PID=$!
 

--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -78,14 +78,14 @@ fi
 if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   echo "EXPERIMENT_MODE=$EXPERIMENT_MODE"
 
-#  docker pull qdrant/vector-db-benchmark:latest
+  docker pull qdrant/vector-db-benchmark:latest
 
   echo "Starting ci-benchmark-upload container"
   docker run \
     --rm \
     --name ci-benchmark-upload \
     -v "$HOME/results/parallel:/code/results" \
-    vector-db-benchmark:el_latest \
+    qdrant/vector-db-benchmark:latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search --skip-configure &
   UPLOAD_PID=$!
 
@@ -94,7 +94,7 @@ if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
     --rm \
     --name ci-benchmark-search \
     -v "$HOME/results/parallel:/code/results" \
-    vector-db-benchmark:el_latest \
+    qdrant/vector-db-benchmark:latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload &
   SEARCH_PID=$!
 

--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -84,7 +84,7 @@ if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   docker run \
     --rm \
     --name ci-benchmark-upload \
-    -v "$HOME/results:/code/results" \
+    -v "$HOME/results/parallel:/code/results" \
     qdrant/vector-db-benchmark:latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search --skip-configure &
   UPLOAD_PID=$!
@@ -93,7 +93,7 @@ if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   docker run \
     --rm \
     --name ci-benchmark-search \
-    -v "$HOME/results:/code/results" \
+    -v "$HOME/results/parallel:/code/results" \
     qdrant/vector-db-benchmark:latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload &
   SEARCH_PID=$!

--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -29,7 +29,7 @@ if [[ -z "$PRIVATE_IP_OF_THE_SERVER" ]]; then
 fi
 
 if [[ -z "$EXPERIMENT_MODE" ]]; then
-  echo "EXPERIMENT_MODE is not set, possible values are: full | upload | search | snapshot"
+  echo "EXPERIMENT_MODE is not set, possible values are: full | upload | search | snapshot | parallel"
   exit 1
 fi
 
@@ -72,6 +72,37 @@ if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "search" ]]; t
     -v "$HOME/results:/code/results" \
     qdrant/vector-db-benchmark:latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload
+fi
+
+
+if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
+  echo "EXPERIMENT_MODE=$EXPERIMENT_MODE"
+
+#  docker pull qdrant/vector-db-benchmark:latest
+
+  echo "Starting ci-benchmark-upload container"
+  docker run \
+    --rm \
+    --name ci-benchmark-upload \
+    -v "$HOME/results:/code/results" \
+    vector-db-benchmark:el_latest \
+    python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search --skip-configure &
+  UPLOAD_PID=$!
+
+  echo "Starting ci-benchmark-search container"
+  docker run \
+    --rm \
+    --name ci-benchmark-search \
+    -v "$HOME/results:/code/results" \
+    vector-db-benchmark:el_latest \
+    python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload &
+  SEARCH_PID=$!
+
+  echo "Waiting for both containers to finish"
+  wait $UPLOAD_PID
+  wait $SEARCH_PID
+
+  echo "EXPERIMENT_MODE=$EXPERIMENT_MODE DONE"
 fi
 
 

--- a/tools/run_experiment.sh
+++ b/tools/run_experiment.sh
@@ -78,14 +78,14 @@ fi
 if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
   echo "EXPERIMENT_MODE=$EXPERIMENT_MODE"
 
-#  docker pull qdrant/vector-db-benchmark:latest
+  docker pull qdrant/vector-db-benchmark:latest
 
   echo "Starting ci-benchmark-upload container"
   docker run \
     --rm \
     --name ci-benchmark-upload \
     -v "$HOME/results:/code/results" \
-    vector-db-benchmark:el_latest \
+    qdrant/vector-db-benchmark:latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-search --skip-configure &
   UPLOAD_PID=$!
 
@@ -94,7 +94,7 @@ if [[ "$EXPERIMENT_MODE" == "parallel" ]]; then
     --rm \
     --name ci-benchmark-search \
     -v "$HOME/results:/code/results" \
-    vector-db-benchmark:el_latest \
+    qdrant/vector-db-benchmark:latest \
     python run.py --engines "${ENGINE_NAME}" --datasets "${DATASETS}" --host "${PRIVATE_IP_OF_THE_SERVER}" --no-skip-if-exists --skip-upload &
   SEARCH_PID=$!
 

--- a/tools/run_remote_benchmark.sh
+++ b/tools/run_remote_benchmark.sh
@@ -85,6 +85,22 @@ case "$BENCHMARK_STRATEGY" in
   bash -x "${SCRIPT_PATH}/qdrant_collect_stats.sh" "$SERVER_CONTAINER_NAME"
   ;;
 
+  "parallel")
+  echo "Parallel benchmark, run upload&search at the same time"
+
+  SERVER_CONTAINER_NAME=${SERVER_CONTAINER_NAME:-"qdrant-continuous-benchmarks-with-volume"}
+
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME"
+
+  bash -x "${SCRIPT_PATH}/run_client_script.sh" "upload"
+
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME" "25Gb" "continue"
+
+  bash -x "${SCRIPT_PATH}/run_client_script.sh" "parallel"
+
+  bash -x "${SCRIPT_PATH}/qdrant_collect_stats.sh" "$SERVER_CONTAINER_NAME"
+  ;;
+
   *)
     echo "Invalid BENCHMARK_STRATEGY value: $BENCHMARK_STRATEGY"
     exit 1

--- a/tools/run_remote_benchmark.sh
+++ b/tools/run_remote_benchmark.sh
@@ -96,6 +96,10 @@ case "$BENCHMARK_STRATEGY" in
 
   bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME" "25Gb" "continue"
 
+  bash -x "${SCRIPT_PATH}/run_client_script.sh" "search"
+
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME" "25Gb" "continue"
+
   bash -x "${SCRIPT_PATH}/run_client_script.sh" "parallel"
 
   bash -x "${SCRIPT_PATH}/qdrant_collect_stats.sh" "$SERVER_CONTAINER_NAME"

--- a/tools/run_remote_benchmark.sh
+++ b/tools/run_remote_benchmark.sh
@@ -58,7 +58,7 @@ case "$BENCHMARK_STRATEGY" in
 
   SERVER_CONTAINER_NAME=${SERVER_CONTAINER_NAME:-"qdrant-continuous-benchmarks-with-volume"}
 
-  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME"
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME" "25Gb"
 
   bash -x "${SCRIPT_PATH}/run_client_script.sh" "upload"
 
@@ -74,7 +74,7 @@ case "$BENCHMARK_STRATEGY" in
 
   SERVER_CONTAINER_NAME=${SERVER_CONTAINER_NAME:-"qdrant-continuous-benchmarks-snapshot"}
 
-  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME"
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME" "25Gb"
 
   bash -x "${SCRIPT_PATH}/run_client_script.sh" "snapshot"
 
@@ -90,7 +90,7 @@ case "$BENCHMARK_STRATEGY" in
 
   SERVER_CONTAINER_NAME=${SERVER_CONTAINER_NAME:-"qdrant-continuous-benchmarks-with-volume"}
 
-  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME"
+  bash -x "${SCRIPT_PATH}/run_server_container_with_volume.sh" "$SERVER_CONTAINER_NAME" "25Gb"
 
   bash -x "${SCRIPT_PATH}/run_client_script.sh" "upload"
 

--- a/tools/run_server_container_with_volume.sh
+++ b/tools/run_server_container_with_volume.sh
@@ -38,10 +38,13 @@ if [[ ${QDRANT_VERSION} == docker/* ]] || [[ ${QDRANT_VERSION} == ghcr/* ]]; the
     if [[ "$EXECUTION_MODE" == "init" ]]; then
       echo "Initialize qdrant from scratch, with qdrant_storage volume"
       DOCKER_COMPOSE="export QDRANT_VERSION=${QDRANT_VERSION}; export CONTAINER_REGISTRY=${CONTAINER_REGISTRY}; export CONTAINER_MEM_LIMIT=${CONTAINER_MEM_LIMIT}; docker compose down; pkill qdrant; docker rm -f qdrant-continuous || true; docker rmi -f ${CONTAINER_REGISTRY}/qdrant/qdrant:${QDRANT_VERSION} || true; docker volume rm -f qdrant_storage || true; docker compose up -d; docker container ls -a"
-    else
+    elif [[ "$EXECUTION_MODE" == "continue" ]]; then
       # suggest that volume qdrant_storage exist and start qdrant
       echo "Reload qdrant with existing data"
       DOCKER_COMPOSE="export QDRANT_VERSION=${QDRANT_VERSION}; export CONTAINER_REGISTRY=${CONTAINER_REGISTRY}; export CONTAINER_MEM_LIMIT=${CONTAINER_MEM_LIMIT}; docker compose down; pkill qdrant; docker rm -f qdrant-continuous || true; docker rmi -f ${CONTAINER_REGISTRY}/qdrant/qdrant:${QDRANT_VERSION} || true ; sudo bash -c 'sync; echo 1 > /proc/sys/vm/drop_caches'; docker compose up -d; docker container ls -a"
+    else
+      echo "Error: unknown execution mode ${EXECUTION_MODE}. Execution mode should be 'init' or 'continue'"
+      exit 1
     fi
 
     ssh -t  -o ServerAliveInterval=60 -o ServerAliveCountMax=3 "${SERVER_USERNAME}@${IP_OF_THE_SERVER}" "cd ./projects/vector-db-benchmark/engine/servers/${CONTAINER_NAME} ; $DOCKER_COMPOSE"

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+
+# Read search results from json file and upload it to postgres
+#
+# Assume table:
+# create table benchmark_parallel_search_upload (
+# 	id SERIAL PRIMARY key,
+# 	engine VARCHAR(255),
+# 	branch VARCHAR(255),
+# 	commit CHAR(40),
+# 	dataset VARCHAR(255),
+# 	measure_timestamp TIMESTAMP,
+# 	upload_time real,
+# 	indexing_time real,
+# 	rps real,
+# 	mean_precisions real,
+# 	p95_time real,
+# 	p99_time real,
+# 	search_time real,
+# );
+
+SEARCH_RESULTS_FILE=${SEARCH_RESULTS_FILE:-""}
+UPLOAD_RESULTS_FILE=${UPLOAD_RESULTS_FILE:-""}
+ROOT_API_RESPONSE_FILE=${ROOT_API_RESPONSE_FILE:-""}
+POSTGRES_TABLE=${POSTGRES_TABLE:-"benchmark_parallel_search_upload"}
+
+QDRANT_VERSION=${QDRANT_VERSION:-"dev"}
+DATASETS=${DATASETS:-"laion-small-clip"}
+
+if [[ "$BENCHMARK_STRATEGY" != "parallel" ]]; then
+  echo "BENCHMARK_STRATEGY is not parallel"
+  exit 1
+else
+  if [[ -z "$SEARCH_RESULTS_FILE" ]]; then
+    echo "SEARCH_RESULTS_FILE is not set"
+    exit 1
+  fi
+
+  if [[ -z "$UPLOAD_RESULTS_FILE" ]]; then
+    echo "UPLOAD_RESULTS_FILE is not set"
+    exit 1
+  fi
+fi
+
+if [[ -z "$ROOT_API_RESPONSE_FILE" ]]; then
+  echo "ROOT_API_RESPONSE_FILE is not set"
+  exit 1
+fi
+
+RPS=NULL
+MEAN_PRECISIONS=NULL
+P95_TIME=NULL
+P99_TIME=NULL
+UPLOAD_TIME=NULL
+INDEXING_TIME=NULL
+SEARCH_TIME=NULL
+
+RPS=$(jq -r '.results.rps' "$SEARCH_RESULTS_FILE")
+MEAN_PRECISIONS=$(jq -r '.results.mean_precisions' "$SEARCH_RESULTS_FILE")
+P95_TIME=$(jq -r '.results.p95_time' "$SEARCH_RESULTS_FILE")
+P99_TIME=$(jq -r '.results.p99_time' "$SEARCH_RESULTS_FILE")
+SEARCH_TIME=$(jq -r '.results.total_time' "$SEARCH_RESULTS_FILE")
+
+UPLOAD_TIME=$(jq -r '.results.upload_time' "$UPLOAD_RESULTS_FILE")
+INDEXING_TIME=$(jq -r '.results.total_time' "$UPLOAD_RESULTS_FILE")
+
+QDRANT_COMMIT=$(jq -r '.commit' "$ROOT_API_RESPONSE_FILE")
+
+MEASURE_TIMESTAMP=${MEASURE_TIMESTAMP:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
+
+
+docker run --name "vector-db" --rm jbergknoff/postgresql-client "postgresql://qdrant:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/postgres" -c "
+INSERT INTO ${POSTGRES_TABLE} (engine, branch, commit, dataset, measure_timestamp, upload_time, indexing_time, rps, mean_precisions, p95_time, p99_time, search_time)
+VALUES ('qdrant-ci', '${QDRANT_VERSION}', '${QDRANT_COMMIT}', '${DATASETS}', '${MEASURE_TIMESTAMP}', ${UPLOAD_TIME}, ${INDEXING_TIME}, ${RPS}, ${MEAN_PRECISIONS}, ${P95_TIME}, ${P99_TIME}, ${SEARCH_TIME});
+"
+

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -18,7 +18,7 @@
 # 	p95_time real,
 # 	p99_time real,
 # 	search_time real,
-#   no_upsert_search_time real,
+# 	no_upsert_search_time real,
 # );
 
 PARALLEL_SEARCH_RESULTS_FILE=${PARALLEL_SEARCH_RESULTS_FILE:-""}

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -18,7 +18,7 @@
 # 	p95_time real,
 # 	p99_time real,
 # 	search_time real,
-#   no_upsert_search_time real,
+#     no_upsert_search_time real,
 # );
 
 SEARCH_RESULTS_FILE=${SEARCH_RESULTS_FILE:-""}

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -18,9 +18,11 @@
 # 	p95_time real,
 # 	p99_time real,
 # 	search_time real,
+#   no_upsert_search_time real,
 # );
 
 SEARCH_RESULTS_FILE=${SEARCH_RESULTS_FILE:-""}
+NO_UPSERT_SEARCH_RESULT_FILE=${NO_UPSERT_SEARCH_RESULT_FILE:-""}
 UPLOAD_RESULTS_FILE=${UPLOAD_RESULTS_FILE:-""}
 ROOT_API_RESPONSE_FILE=${ROOT_API_RESPONSE_FILE:-""}
 POSTGRES_TABLE=${POSTGRES_TABLE:-"benchmark_parallel_search_upload"}
@@ -34,6 +36,11 @@ if [[ "$BENCHMARK_STRATEGY" != "parallel" ]]; then
 else
   if [[ -z "$SEARCH_RESULTS_FILE" ]]; then
     echo "SEARCH_RESULTS_FILE is not set"
+    exit 1
+  fi
+
+  if [[ -z "$NO_UPSERT_SEARCH_RESULT_FILE" ]]; then
+    echo "NO_UPSERT_SEARCH_RESULT_FILE is not set"
     exit 1
   fi
 
@@ -61,6 +68,7 @@ MEAN_PRECISIONS=$(jq -r '.results.mean_precisions' "$SEARCH_RESULTS_FILE")
 P95_TIME=$(jq -r '.results.p95_time' "$SEARCH_RESULTS_FILE")
 P99_TIME=$(jq -r '.results.p99_time' "$SEARCH_RESULTS_FILE")
 SEARCH_TIME=$(jq -r '.results.total_time' "$SEARCH_RESULTS_FILE")
+NO_UPSERT_SEARCH_TIME=$(jq -r '.results.total_time' "$NO_UPSERT_SEARCH_RESULT_FILE")
 
 UPLOAD_TIME=$(jq -r '.results.upload_time' "$UPLOAD_RESULTS_FILE")
 INDEXING_TIME=$(jq -r '.results.total_time' "$UPLOAD_RESULTS_FILE")
@@ -71,7 +79,7 @@ MEASURE_TIMESTAMP=${MEASURE_TIMESTAMP:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
 
 
 docker run --name "vector-db" --rm jbergknoff/postgresql-client "postgresql://qdrant:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/postgres" -c "
-INSERT INTO ${POSTGRES_TABLE} (engine, branch, commit, dataset, measure_timestamp, upload_time, indexing_time, rps, mean_precisions, p95_time, p99_time, search_time)
-VALUES ('qdrant-ci', '${QDRANT_VERSION}', '${QDRANT_COMMIT}', '${DATASETS}', '${MEASURE_TIMESTAMP}', ${UPLOAD_TIME}, ${INDEXING_TIME}, ${RPS}, ${MEAN_PRECISIONS}, ${P95_TIME}, ${P99_TIME}, ${SEARCH_TIME});
+INSERT INTO ${POSTGRES_TABLE} (engine, branch, commit, dataset, measure_timestamp, upload_time, indexing_time, rps, mean_precisions, p95_time, p99_time, search_time, no_upsert_search_time)
+VALUES ('qdrant-ci', '${QDRANT_VERSION}', '${QDRANT_COMMIT}', '${DATASETS}', '${MEASURE_TIMESTAMP}', ${UPLOAD_TIME}, ${INDEXING_TIME}, ${RPS}, ${MEAN_PRECISIONS}, ${P95_TIME}, ${P99_TIME}, ${SEARCH_TIME}, ${NO_UPSERT_SEARCH_TIME});
 "
 

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -18,7 +18,7 @@
 # 	p95_time real,
 # 	p99_time real,
 # 	search_time real,
-#     no_upsert_search_time real,
+#   no_upsert_search_time real,
 # );
 
 SEARCH_RESULTS_FILE=${SEARCH_RESULTS_FILE:-""}

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -21,8 +21,9 @@
 #   no_upsert_search_time real,
 # );
 
-SEARCH_RESULTS_FILE=${SEARCH_RESULTS_FILE:-""}
-NO_UPSERT_SEARCH_RESULT_FILE=${NO_UPSERT_SEARCH_RESULT_FILE:-""}
+PARALLEL_SEARCH_RESULTS_FILE=${PARALLEL_SEARCH_RESULTS_FILE:-""}
+SEARCH_RESULT_FILE=${SEARCH_RESULTS_FILE:-""}
+PARALLEL_UPLOAD_RESULTS_FILE=${PARALLEL_UPLOAD_RESULTS_FILE:-""}
 UPLOAD_RESULTS_FILE=${UPLOAD_RESULTS_FILE:-""}
 ROOT_API_RESPONSE_FILE=${ROOT_API_RESPONSE_FILE:-""}
 POSTGRES_TABLE=${POSTGRES_TABLE:-"benchmark_parallel_search_upload"}
@@ -34,13 +35,18 @@ if [[ "$BENCHMARK_STRATEGY" != "parallel" ]]; then
   echo "BENCHMARK_STRATEGY is not parallel"
   exit 1
 else
-  if [[ -z "$SEARCH_RESULTS_FILE" ]]; then
-    echo "SEARCH_RESULTS_FILE is not set"
+  if [[ -z "$PARALLEL_SEARCH_RESULTS_FILE" ]]; then
+    echo "PARALLEL_SEARCH_RESULTS_FILE is not set"
     exit 1
   fi
 
-  if [[ -z "$NO_UPSERT_SEARCH_RESULT_FILE" ]]; then
-    echo "NO_UPSERT_SEARCH_RESULT_FILE is not set"
+  if [[ -z "$SEARCH_RESULT_FILE" ]]; then
+    echo "SEARCH_RESULT_FILE is not set"
+    exit 1
+  fi
+
+  if [[ -z "$PARALLEL_UPLOAD_RESULTS_FILE" ]]; then
+    echo "PARALLEL_UPLOAD_RESULTS_FILE is not set"
     exit 1
   fi
 
@@ -62,16 +68,17 @@ P99_TIME=NULL
 UPLOAD_TIME=NULL
 INDEXING_TIME=NULL
 SEARCH_TIME=NULL
+NO_UPSERT_SEARCH_TIME=NULL
 
-RPS=$(jq -r '.results.rps' "$SEARCH_RESULTS_FILE")
-MEAN_PRECISIONS=$(jq -r '.results.mean_precisions' "$SEARCH_RESULTS_FILE")
-P95_TIME=$(jq -r '.results.p95_time' "$SEARCH_RESULTS_FILE")
-P99_TIME=$(jq -r '.results.p99_time' "$SEARCH_RESULTS_FILE")
-SEARCH_TIME=$(jq -r '.results.total_time' "$SEARCH_RESULTS_FILE")
-NO_UPSERT_SEARCH_TIME=$(jq -r '.results.total_time' "$NO_UPSERT_SEARCH_RESULT_FILE")
+RPS=$(jq -r '.results.rps' "$PARALLEL_SEARCH_RESULTS_FILE")
+MEAN_PRECISIONS=$(jq -r '.results.mean_precisions' "$PARALLEL_SEARCH_RESULTS_FILE")
+P95_TIME=$(jq -r '.results.p95_time' "$PARALLEL_SEARCH_RESULTS_FILE")
+P99_TIME=$(jq -r '.results.p99_time' "$PARALLEL_SEARCH_RESULTS_FILE")
+SEARCH_TIME=$(jq -r '.results.total_time' "$PARALLEL_SEARCH_RESULTS_FILE")
+NO_UPSERT_SEARCH_TIME=$(jq -r '.results.total_time' "$SEARCH_RESULT_FILE")
 
-UPLOAD_TIME=$(jq -r '.results.upload_time' "$UPLOAD_RESULTS_FILE")
-INDEXING_TIME=$(jq -r '.results.total_time' "$UPLOAD_RESULTS_FILE")
+UPLOAD_TIME=$(jq -r '.results.upload_time' "$PARALLEL_UPLOAD_RESULTS_FILE")
+INDEXING_TIME=$(jq -r '.results.total_time' "$PARALLEL_UPLOAD_RESULTS_FILE")
 
 QDRANT_COMMIT=$(jq -r '.commit' "$ROOT_API_RESPONSE_FILE")
 


### PR DESCRIPTION
* introduce new cli arg `--skip-configure` to `run.py`, that allows for skipping collection re-creation during the upload stage. It is optional, and set to `False` by default, so it has no effect on any other benchmarks.
* add a new experiment mode `parallel`, run upload and search containers at the same time during that experiment
* add a new table to store the new benchmark's results 

**Note**: the benchmark stores search_time in the above table, that corresponds to `results.total_time` (a value measured by python `time.perf_counter()` to calculate time spend on executing all search queries)