### PR TITLE
Complete compare versions' workflow

### DIFF
--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -139,11 +139,11 @@ jobs:
             if (( $(echo "$value_v1 > $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v1 - $value_v2" | bc -l)
               local percentage=$(echo "($diff / $value_v1) * 100" | bc -l)
-              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% faster)\033[0m"
+              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% greater)\033[0m"
             elif (( $(echo "$value_v1 < $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v2 - $value_v1" | bc -l)
               local percentage=$(echo "($diff / $value_v2) * 100" | bc -l)
-              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% slower)\033[0m"
+              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% less)\033[0m"
             else
               echo -e "\033[32m${var_name} are equal for both versions\033[0m"
             fi

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -149,12 +149,25 @@ jobs:
             fi
           }
 
-          compare "collection_load_time" "${{ needs.runBenchmarkForVersion1.outputs.collection_load_time }}" "${{ needs.runBenchmarkForVersion2.outputs.collection_load_time }}"
-          compare "rps" "${{ needs.runBenchmarkForVersion1.outputs.rps }}" "${{ needs.runBenchmarkForVersion2.outputs.rps }}"
-          compare "mean_precisions" "${{ needs.runBenchmarkForVersion1.outputs.mean_precisions }}" "${{ needs.runBenchmarkForVersion2.outputs.mean_precisions }}"
-          compare "p95_time" "${{ needs.runBenchmarkForVersion1.outputs.p95_time }}" "${{ needs.runBenchmarkForVersion2.outputs.p95_time }}"
-          compare "p99_time" "${{ needs.runBenchmarkForVersion1.outputs.p99_time }}" "${{ needs.runBenchmarkForVersion2.outputs.p99_time }}"
-          compare "vm_rss_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.vm_rss_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.vm_rss_memory_usage }}"
-          compare "rss_anon_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.rss_anon_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.rss_anon_memory_usage }}"
-          compare "upload_time" "${{ needs.runBenchmarkForVersion1.outputs.upload_time }}" "${{ needs.runBenchmarkForVersion2.outputs.upload_time }}"
-          compare "indexing_time" "${{ needs.runBenchmarkForVersion1.outputs.indexing_time }}" "${{ needs.runBenchmarkForVersion2.outputs.indexing_time }}"
+          res_collection_load_time=$(compare "collection_load_time" "${{ needs.runBenchmarkForVersion1.outputs.collection_load_time }}" "${{ needs.runBenchmarkForVersion2.outputs.collection_load_time }}")
+          res_rps=$(compare "rps" "${{ needs.runBenchmarkForVersion1.outputs.rps }}" "${{ needs.runBenchmarkForVersion2.outputs.rps }}")
+          res_mean_precisions=$(compare "mean_precisions" "${{ needs.runBenchmarkForVersion1.outputs.mean_precisions }}" "${{ needs.runBenchmarkForVersion2.outputs.mean_precisions }}")
+          res_p95_time=$(compare "p95_time" "${{ needs.runBenchmarkForVersion1.outputs.p95_time }}" "${{ needs.runBenchmarkForVersion2.outputs.p95_time }}")
+          res_p99_time=$(compare "p99_time" "${{ needs.runBenchmarkForVersion1.outputs.p99_time }}" "${{ needs.runBenchmarkForVersion2.outputs.p99_time }}")
+          res_vm_rss_memory_usage=$(compare "vm_rss_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.vm_rss_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.vm_rss_memory_usage }}")
+          res_rss_anon_memory_usage=$(compare "rss_anon_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.rss_anon_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.rss_anon_memory_usage }}")
+          res_upload_time=$(compare "upload_time" "${{ needs.runBenchmarkForVersion1.outputs.upload_time }}" "${{ needs.runBenchmarkForVersion2.outputs.upload_time }}")
+          res_indexing_time=$(compare "indexing_time" "${{ needs.runBenchmarkForVersion1.outputs.indexing_time }}" "${{ needs.runBenchmarkForVersion2.outputs.indexing_time }}")
+
+          echo "# Comparison results" >> $GITHUB_STEP_SUMMARY
+          echo "| Name                  | Result       |" >> $GITHUB_STEP_SUMMARY
+          echo "| --------------------- | ------------ |" >> $GITHUB_STEP_SUMMARY
+          echo "| collection_load_time  | ${res_collection_load_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| rps                   | ${res_rps} |" >> $GITHUB_STEP_SUMMARY
+          echo "| mean_precisions       | ${res_mean_precisions} |" >> $GITHUB_STEP_SUMMARY
+          echo "| p95_time              | ${res_p95_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| p99_time              | ${res_p99_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| vm_rss_memory_usage   | ${res_vm_rss_memory_usage} |" >> $GITHUB_STEP_SUMMARY
+          echo "| rss_anon_memory_usage  | ${res_rss_anon_memory_usage} |" >> $GITHUB_STEP_SUMMARY
+          echo "| upload_time           | ${res_upload_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| indexing_time         | ${res_indexing_time} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -139,13 +139,13 @@ jobs:
             if (( $(echo "$value_v1 > $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v1 - $value_v2" | bc -l)
               local percentage=$(echo "($diff / $value_v1) * 100" | bc -l)
-              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% greater)\033[0m"
+              echo -e "${{ inputs.qdrant_version_1 }} > ${{ inputs.qdrant_version_2 }} by $diff ($percentage% greater)"
             elif (( $(echo "$value_v1 < $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v2 - $value_v1" | bc -l)
               local percentage=$(echo "($diff / $value_v2) * 100" | bc -l)
-              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% less)\033[0m"
+              echo -e "${{ inputs.qdrant_version_1 }} < ${{ inputs.qdrant_version_2 }} by $diff ($percentage% less)"
             else
-              echo -e "\033[32m${var_name} are equal for both versions\033[0m"
+              echo -e "equal"
             fi
           }
 
@@ -160,14 +160,14 @@ jobs:
           res_indexing_time=$(compare "indexing_time" "${{ needs.runBenchmarkForVersion1.outputs.indexing_time }}" "${{ needs.runBenchmarkForVersion2.outputs.indexing_time }}")
 
           echo "# Comparison results" >> $GITHUB_STEP_SUMMARY
-          echo "| Name                  | Result       |" >> $GITHUB_STEP_SUMMARY
+          echo "| Name                  | ${{ inputs.qdrant_version_1 }}       | ${{ inputs.qdrant_version_2 }}       | Result     |" >> $GITHUB_STEP_SUMMARY
           echo "| --------------------- | ------------ |" >> $GITHUB_STEP_SUMMARY
-          echo "| collection_load_time  | ${res_collection_load_time} |" >> $GITHUB_STEP_SUMMARY
-          echo "| rps                   | ${res_rps} |" >> $GITHUB_STEP_SUMMARY
-          echo "| mean_precisions       | ${res_mean_precisions} |" >> $GITHUB_STEP_SUMMARY
-          echo "| p95_time              | ${res_p95_time} |" >> $GITHUB_STEP_SUMMARY
-          echo "| p99_time              | ${res_p99_time} |" >> $GITHUB_STEP_SUMMARY
-          echo "| vm_rss_memory_usage   | ${res_vm_rss_memory_usage} |" >> $GITHUB_STEP_SUMMARY
-          echo "| rss_anon_memory_usage  | ${res_rss_anon_memory_usage} |" >> $GITHUB_STEP_SUMMARY
-          echo "| upload_time           | ${res_upload_time} |" >> $GITHUB_STEP_SUMMARY
-          echo "| indexing_time         | ${res_indexing_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| collection_load_time  | ${{ needs.runBenchmarkForVersion1.outputs.collection_load_time }} | ${{ needs.runBenchmarkForVersion2.outputs.collection_load_time }} | ${res_collection_load_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| rps                   | ${{ needs.runBenchmarkForVersion1.outputs.rps }} | ${{ needs.runBenchmarkForVersion2.outputs.rps }} | ${res_rps} |" >> $GITHUB_STEP_SUMMARY
+          echo "| mean_precisions       | ${{ needs.runBenchmarkForVersion1.outputs.mean_precisions }} | ${{ needs.runBenchmarkForVersion2.outputs.mean_precisions }} | ${res_mean_precisions} |" >> $GITHUB_STEP_SUMMARY
+          echo "| p95_time              | ${{ needs.runBenchmarkForVersion1.outputs.p95_time }} | ${{ needs.runBenchmarkForVersion2.outputs.p95_time }} | ${res_p95_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| p99_time              | ${{ needs.runBenchmarkForVersion1.outputs.p99_time }} | ${{ needs.runBenchmarkForVersion2.outputs.p99_time }} | ${res_p99_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| vm_rss_memory_usage   | ${{ needs.runBenchmarkForVersion1.outputs.vm_rss_memory_usage }} | ${{ needs.runBenchmarkForVersion2.outputs.vm_rss_memory_usage }} | ${res_vm_rss_memory_usage} |" >> $GITHUB_STEP_SUMMARY
+          echo "| rss_anon_memory_usage  | ${{ needs.runBenchmarkForVersion1.outputs.rss_anon_memory_usage }} | ${{ needs.runBenchmarkForVersion2.outputs.rss_anon_memory_usage }} | ${res_rss_anon_memory_usage} |" >> $GITHUB_STEP_SUMMARY
+          echo "| upload_time           | ${{ needs.runBenchmarkForVersion1.outputs.upload_time }} | ${{ needs.runBenchmarkForVersion2.outputs.upload_time }} | ${res_upload_time} |" >> $GITHUB_STEP_SUMMARY
+          echo "| indexing_time         | ${{ needs.runBenchmarkForVersion1.outputs.indexing_time }} | ${{ needs.runBenchmarkForVersion2.outputs.indexing_time }} | ${res_indexing_time} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -46,47 +46,87 @@ jobs:
           export BEARER_TOKEN="${{ secrets.TRIGGER_GH_TOKEN }}"
           bash -x tools/compare_versions/prepare_image.sh
 
-#  runBenchmarkForVersion1:
-#    name: compare - ${{ inputs.qdrant_version_1 }} vs ${{ inputs.qdrant_version_2 }} - ${{ inputs.dataset }}
-#    needs:
-#      - prepareImage1
-#      - prepareImage2
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Bench ${{ inputs.qdrant_version_1 }}
-#        run: |
-#          export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#          export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#          export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#          export QDRANT_VERSION=${{ inputs.qdrant_version_1 }}
-#          export DATASETS=${{ inputs.dataset }}
-#          export ENGINE_NAME=${{ inputs.engine_config }}
-#          export POSTGRES_TABLE=benchmark_manual
-#          bash -x tools/setup_ci.sh
-#          bash -x tools/run_ci.sh
-#
-#  runBenchmarkForVersion2:
-#    name: compare - ${{ inputs.qdrant_version_1 }} vs ${{ inputs.qdrant_version_2 }} - ${{ inputs.dataset }}
-#    needs:
-#      - runBenchmarkForVersion1
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Bench ${{ inputs.qdrant_version_2 }}
-#        run: |
-#          export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#          export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#          export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#          export QDRANT_VERSION=${{ inputs.qdrant_version_2 }}
-#          export DATASETS=${{ inputs.dataset }}
-#          export ENGINE_NAME=${{ inputs.engine_config }}
-#          export POSTGRES_TABLE=benchmark_manual
-#          bash -x tools/setup_ci.sh
-#          bash -x tools/run_ci.sh
+  runBenchmarkForVersion1:
+    name: execute - ${{ inputs.qdrant_version_1 }} - ${{ inputs.dataset }}
+    needs:
+      - prepareImage1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Bench ${{ inputs.qdrant_version_1 }}
+        run: |
+          export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+          export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+          export QDRANT_VERSION=${{ inputs.qdrant_version_1 }}
+          export DATASETS=${{ inputs.dataset }}
+          export ENGINE_NAME=${{ inputs.engine_config }}
+          export POSTGRES_TABLE=benchmark_manual
+          bash -x tools/setup_ci.sh
+          bash -x tools/run_ci.sh
+
+  runBenchmarkForVersion2:
+    name: execute - ${{ inputs.qdrant_version_2 }} - ${{ inputs.dataset }}
+    needs:
+      - prepareImage2
+      - runBenchmarkForVersion1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Bench ${{ inputs.qdrant_version_2 }}
+        run: |
+          export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+          export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+          export QDRANT_VERSION=${{ inputs.qdrant_version_2 }}
+          export DATASETS=${{ inputs.dataset }}
+          export ENGINE_NAME=${{ inputs.engine_config }}
+          export POSTGRES_TABLE=benchmark_manual
+          bash -x tools/setup_ci.sh
+          bash -x tools/run_ci.sh
+
+  compareVersions:
+    name: compare - ${{ inputs.qdrant_version_1 }} vs ${{ inputs.qdrant_version_2 }}
+    needs:
+      - runBenchmarkForVersion1
+      - runBenchmarkForVersion2
+    runs-on: ubuntu-latest
+    steps:
+      - name: compare
+        run: |
+          compare() {
+            local var_name=$1
+            local value_v1=${{ needs.runBenchmarkForVersion1.outputs.${var_name} }}
+            local value_v2=${{ needs.runBenchmarkForVersion2.outputs.${var_name} }}
+  
+            echo "${{ inputs.qdrant_version_1 }}: ${var_name}=${value_v1}"
+            echo "${{ inputs.qdrant_version_2 }}: ${var_name}=${value_v2}"
+  
+            if (( $(echo "$value_v1 > $value_v2" | bc -l) )); then
+              local diff=$(echo "$value_v1 - $value_v2" | bc -l)
+              local percentage=$(echo "($diff / $value_v1) * 100" | bc -l)
+              echo "${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% faster)"
+            elif (( $(echo "$value_v1 < $value_v2" | bc -l) )); then
+              local diff=$(echo "$value_v2 - $value_v1" | bc -l)
+              local percentage=$(echo "($diff / $value_v2) * 100" | bc -l)
+              echo "${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% slower)"
+            else
+              echo "${var_name} are equal for both versions"
+            fi
+          }
+  
+          compare "collection_load_time"
+          compare "rps"
+          compare "mean_precisions"
+          compare "p95_time"
+          compare "p99_time"
+          compare "vm_rss_memory_usage"
+          compare "rss_anon_memory_usage"
+          compare "upload_time"
+          compare "indexing_time"

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -102,8 +102,8 @@ jobs:
         run: |
           compare() {
             local var_name=$1
-            local value_v1=${{ needs.runBenchmarkForVersion1.outputs.${var_name} }}
-            local value_v2=${{ needs.runBenchmarkForVersion2.outputs.${var_name} }}
+            local value_v1=$2
+            local value_v2=$3
   
             echo "${{ inputs.qdrant_version_1 }}: ${var_name}=${value_v1}"
             echo "${{ inputs.qdrant_version_2 }}: ${var_name}=${value_v2}"
@@ -121,12 +121,12 @@ jobs:
             fi
           }
   
-          compare "collection_load_time"
-          compare "rps"
-          compare "mean_precisions"
-          compare "p95_time"
-          compare "p99_time"
-          compare "vm_rss_memory_usage"
-          compare "rss_anon_memory_usage"
-          compare "upload_time"
-          compare "indexing_time"
+          compare "collection_load_time" "${{ needs.runBenchmarkForVersion1.outputs.collection_load_time }}" "${{ needs.runBenchmarkForVersion2.outputs.collection_load_time }}"
+          compare "rps" "${{ needs.runBenchmarkForVersion1.outputs.rps }}" "${{ needs.runBenchmarkForVersion2.outputs.rps }}"
+          compare "mean_precisions" "${{ needs.runBenchmarkForVersion1.outputs.mean_precisions }}" "${{ needs.runBenchmarkForVersion2.outputs.mean_precisions }}"
+          compare "p95_time" "${{ needs.runBenchmarkForVersion1.outputs.p95_time }}" "${{ needs.runBenchmarkForVersion2.outputs.p95_time }}"
+          compare "p99_time" "${{ needs.runBenchmarkForVersion1.outputs.p99_time }}" "${{ needs.runBenchmarkForVersion2.outputs.p99_time }}"
+          compare "vm_rss_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.vm_rss_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.vm_rss_memory_usage }}"
+          compare "rss_anon_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.rss_anon_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.rss_anon_memory_usage }}"
+          compare "upload_time" "${{ needs.runBenchmarkForVersion1.outputs.upload_time }}" "${{ needs.runBenchmarkForVersion2.outputs.upload_time }}"
+          compare "indexing_time" "${{ needs.runBenchmarkForVersion1.outputs.indexing_time }}" "${{ needs.runBenchmarkForVersion2.outputs.indexing_time }}"

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -55,12 +55,23 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: continuous-benchmark
+    outputs:
+      collection_load_time: ${{ steps.bench.outputs.collection_load_time }}
+      rps: ${{ steps.bench.outputs.rps }}
+      mean_precisions: ${{ steps.bench.outputs.mean_precisions }}
+      p95_time: ${{ steps.bench.outputs.p95_time }}
+      p99_time: ${{ steps.bench.outputs.p99_time }}
+      vm_rss_memory_usage: ${{ steps.bench.outputs.vm_rss_memory_usage }}
+      rss_anon_memory_usage: ${{ steps.bench.outputs.rss_anon_memory_usage }}
+      upload_time: ${{ steps.bench.outputs.upload_time }}
+      indexing_time: ${{ steps.bench.outputs.indexing_time }}
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Bench ${{ inputs.qdrant_version_1 }}
+        id: bench
         run: |
           export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
           export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
@@ -80,12 +91,23 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: continuous-benchmark
+    outputs:
+      collection_load_time: ${{ steps.bench.outputs.collection_load_time }}
+      rps: ${{ steps.bench.outputs.rps }}
+      mean_precisions: ${{ steps.bench.outputs.mean_precisions }}
+      p95_time: ${{ steps.bench.outputs.p95_time }}
+      p99_time: ${{ steps.bench.outputs.p99_time }}
+      vm_rss_memory_usage: ${{ steps.bench.outputs.vm_rss_memory_usage }}
+      rss_anon_memory_usage: ${{ steps.bench.outputs.rss_anon_memory_usage }}
+      upload_time: ${{ steps.bench.outputs.upload_time }}
+      indexing_time: ${{ steps.bench.outputs.indexing_time }}
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Bench ${{ inputs.qdrant_version_2 }}
+        id: bench
         run: |
           export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
           export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -139,13 +139,13 @@ jobs:
             if (( $(echo "$value_v1 > $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v1 - $value_v2" | bc -l)
               local percentage=$(echo "($diff / $value_v1) * 100" | bc -l)
-              echo "${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% faster)"
+              echo "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% faster)\033[0m"
             elif (( $(echo "$value_v1 < $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v2 - $value_v1" | bc -l)
               local percentage=$(echo "($diff / $value_v2) * 100" | bc -l)
-              echo "${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% slower)"
+              echo "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% slower)\033[0m"
             else
-              echo "${var_name} are equal for both versions"
+              echo "\033[32m${var_name} are equal for both versions\033[0m"
             fi
           }
   

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -133,9 +133,6 @@ jobs:
             local value_v1=$2
             local value_v2=$3
 
-            echo "${{ inputs.qdrant_version_1 }}: ${var_name}=${value_v1}"
-            echo "${{ inputs.qdrant_version_2 }}: ${var_name}=${value_v2}"
-
             if (( $(echo "$value_v1 > $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v1 - $value_v2" | bc -l)
               local percentage=$(echo "($diff / $value_v1) * 100" | bc -l)
@@ -161,7 +158,7 @@ jobs:
 
           echo "# Comparison results" >> $GITHUB_STEP_SUMMARY
           echo "| Name                  | ${{ inputs.qdrant_version_1 }}       | ${{ inputs.qdrant_version_2 }}       | Result     |" >> $GITHUB_STEP_SUMMARY
-          echo "| --------------------- | ------------ |" >> $GITHUB_STEP_SUMMARY
+          echo "| --------------------- | ------------ | ------------ | ------------ |" >> $GITHUB_STEP_SUMMARY
           echo "| collection_load_time  | ${{ needs.runBenchmarkForVersion1.outputs.collection_load_time }} | ${{ needs.runBenchmarkForVersion2.outputs.collection_load_time }} | ${res_collection_load_time} |" >> $GITHUB_STEP_SUMMARY
           echo "| rps                   | ${{ needs.runBenchmarkForVersion1.outputs.rps }} | ${{ needs.runBenchmarkForVersion2.outputs.rps }} | ${res_rps} |" >> $GITHUB_STEP_SUMMARY
           echo "| mean_precisions       | ${{ needs.runBenchmarkForVersion1.outputs.mean_precisions }} | ${{ needs.runBenchmarkForVersion2.outputs.mean_precisions }} | ${res_mean_precisions} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -1,4 +1,8 @@
 name: Manual Benchmark to compare versions
+description: |
+  This workflow is used to compare two versions of qdrant using the same dataset and engine config.
+  It is triggered manually and requires the user to provide the versions of qdrant to compare, dataset and engine config.
+  The workflow will prepare the images for the provided versions (if needed), run the benchmark for each version and compare the results.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -132,10 +132,10 @@ jobs:
             local var_name=$1
             local value_v1=$2
             local value_v2=$3
-  
+
             echo "${{ inputs.qdrant_version_1 }}: ${var_name}=${value_v1}"
             echo "${{ inputs.qdrant_version_2 }}: ${var_name}=${value_v2}"
-  
+
             if (( $(echo "$value_v1 > $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v1 - $value_v2" | bc -l)
               local percentage=$(echo "($diff / $value_v1) * 100" | bc -l)
@@ -148,7 +148,7 @@ jobs:
               echo -e "\033[32m${var_name} are equal for both versions\033[0m"
             fi
           }
-  
+
           compare "collection_load_time" "${{ needs.runBenchmarkForVersion1.outputs.collection_load_time }}" "${{ needs.runBenchmarkForVersion2.outputs.collection_load_time }}"
           compare "rps" "${{ needs.runBenchmarkForVersion1.outputs.rps }}" "${{ needs.runBenchmarkForVersion2.outputs.rps }}"
           compare "mean_precisions" "${{ needs.runBenchmarkForVersion1.outputs.mean_precisions }}" "${{ needs.runBenchmarkForVersion2.outputs.mean_precisions }}"

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -139,13 +139,13 @@ jobs:
             if (( $(echo "$value_v1 > $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v1 - $value_v2" | bc -l)
               local percentage=$(echo "($diff / $value_v1) * 100" | bc -l)
-              echo "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% faster)\033[0m"
+              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is greater than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% faster)\033[0m"
             elif (( $(echo "$value_v1 < $value_v2" | bc -l) )); then
               local diff=$(echo "$value_v2 - $value_v1" | bc -l)
               local percentage=$(echo "($diff / $value_v2) * 100" | bc -l)
-              echo "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% slower)\033[0m"
+              echo -e "\033[32m${var_name} for ${{ inputs.qdrant_version_1 }} is less than for ${{ inputs.qdrant_version_2 }} by $diff ($percentage% slower)\033[0m"
             else
-              echo "\033[32m${var_name} are equal for both versions\033[0m"
+              echo -e "\033[32m${var_name} are equal for both versions\033[0m"
             fi
           }
   

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           # The branch, tag or SHA to checkout.
           export QDRANT_VERSION=${{ inputs.qdrant_version_1 }}
-          export BEARER_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export BEARER_TOKEN="${{ secrets.TRIGGER_GH_TOKEN }}"
           bash -x tools/compare_versions/prepare_image.sh
 
   prepareImage2:
@@ -43,7 +43,7 @@ jobs:
       - name: Image for ${{ inputs.qdrant_version_2 }}
         run: |
           export QDRANT_VERSION=${{ inputs.qdrant_version_2 }}
-          export BEARER_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export BEARER_TOKEN="${{ secrets.TRIGGER_GH_TOKEN }}"
           bash -x tools/compare_versions/prepare_image.sh
 
 #  runBenchmarkForVersion1:

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -33,7 +33,7 @@ jobs:
           bash -x tools/compare_versions/prepare_image.sh
 
   prepareImage2:
-    name: Prepare image ${{ inputs.qdrant_version_1 }}
+    name: Prepare image ${{ inputs.qdrant_version_2 }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -20,7 +20,7 @@ jobs:
   prepareImage1:
     name: Prepare image ${{ inputs.qdrant_version_1 }}
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
@@ -36,7 +36,7 @@ jobs:
   prepareImage2:
     name: Prepare image ${{ inputs.qdrant_version_2 }}
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -20,6 +20,7 @@ jobs:
   prepareImage1:
     name: Prepare image ${{ inputs.qdrant_version_1 }}
     runs-on: ubuntu-latest
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
@@ -35,6 +36,7 @@ jobs:
   prepareImage2:
     name: Prepare image ${{ inputs.qdrant_version_2 }}
     runs-on: ubuntu-latest
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
@@ -51,6 +53,8 @@ jobs:
     needs:
       - prepareImage1
     runs-on: ubuntu-latest
+    concurrency:
+      group: continuous-benchmark
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0
@@ -74,6 +78,8 @@ jobs:
       - prepareImage2
       - runBenchmarkForVersion1
     runs-on: ubuntu-latest
+    concurrency:
+      group: continuous-benchmark
     steps:
       - uses: actions/checkout@v3
       - uses: webfactory/ssh-agent@v0.8.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -1586,13 +1586,13 @@ testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metad
 
 [[package]]
 name = "setuptools"
-version = "75.8.1"
+version = "75.8.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "setuptools-75.8.1-py3-none-any.whl", hash = "sha256:3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f"},
-    {file = "setuptools-75.8.1.tar.gz", hash = "sha256:65fb779a8f28895242923582eadca2337285f0891c2c9e160754df917c3d2530"},
+    {file = "setuptools-75.8.2-py3-none-any.whl", hash = "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"},
+    {file = "setuptools-75.8.2.tar.gz", hash = "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1586,13 +1586,13 @@ testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metad
 
 [[package]]
 name = "setuptools"
-version = "75.8.0"
+version = "75.8.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3"},
-    {file = "setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6"},
+    {file = "setuptools-75.8.1-py3-none-any.whl", hash = "sha256:3bc32c0b84c643299ca94e77f834730f126efd621de0cc1de64119e0e17dab1f"},
+    {file = "setuptools-75.8.1.tar.gz", hash = "sha256:65fb779a8f28895242923582eadca2337285f0891c2c9e160754df917c3d2530"},
 ]
 
 [package.extras]

--- a/tools/compare_versions/prepare_image.sh
+++ b/tools/compare_versions/prepare_image.sh
@@ -2,8 +2,7 @@
 
 QDRANT_VERSION=${QDRANT_VERSION:-"ghcr/dev"}
 
-#MAX_RETRIES=12
-MAX_RETRIES=1
+MAX_RETRIES=15
 
 EVENT_TYPE="benchmark-trigger-image-build"
 
@@ -63,9 +62,8 @@ while ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; do
   fi
   # sleep for 10 minutes, in seconds
   # together with the MAX_RETRIES it
-  # will wait for 120 minutes
-#  sleep 600
-  sleep 60
+  # will wait for 150 minutes
+  sleep 600
   ((counter++))
 done
 

--- a/tools/compare_versions/prepare_image.sh
+++ b/tools/compare_versions/prepare_image.sh
@@ -18,10 +18,12 @@ if [[ ${QDRANT_VERSION} == docker/* ]] || [[ ${QDRANT_VERSION} == ghcr/* ]]; the
     if [[ ${QDRANT_VERSION} == docker/* ]]; then
         # pull from docker hub
         QDRANT_VERSION=${QDRANT_VERSION#docker/}
+        QDRANT_VERSION=${QDRANT_VERSION//\//-} # replace all / with -
         CONTAINER_REGISTRY='docker.io'
     elif [[ ${QDRANT_VERSION} == ghcr/* ]]; then
         # pull from github container registry
         QDRANT_VERSION=${QDRANT_VERSION#ghcr/}
+        QDRANT_VERSION=${QDRANT_VERSION//\//-} # replace all / with -
         CONTAINER_REGISTRY='ghcr.io'
     fi
 else

--- a/tools/compare_versions/prepare_image.sh
+++ b/tools/compare_versions/prepare_image.sh
@@ -18,12 +18,12 @@ if [[ ${QDRANT_VERSION} == docker/* ]] || [[ ${QDRANT_VERSION} == ghcr/* ]]; the
     if [[ ${QDRANT_VERSION} == docker/* ]]; then
         # pull from docker hub
         QDRANT_VERSION=${QDRANT_VERSION#docker/}
-        QDRANT_VERSION=${QDRANT_VERSION//\//-} # replace all / with -
+        QDRANT_VERSION_IMG=${QDRANT_VERSION//\//-} # replace all / with -
         CONTAINER_REGISTRY='docker.io'
     elif [[ ${QDRANT_VERSION} == ghcr/* ]]; then
         # pull from github container registry
         QDRANT_VERSION=${QDRANT_VERSION#ghcr/}
-        QDRANT_VERSION=${QDRANT_VERSION//\//-} # replace all / with -
+        QDRANT_VERSION_IMG=${QDRANT_VERSION//\//-} # replace all / with -
         CONTAINER_REGISTRY='ghcr.io'
     fi
 else
@@ -31,7 +31,7 @@ else
     exit 1
 fi
 
-IMAGE="${CONTAINER_REGISTRY}/qdrant/qdrant:${QDRANT_VERSION}"
+IMAGE="${CONTAINER_REGISTRY}/qdrant/qdrant:${QDRANT_VERSION_IMG}"
 
 if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
   echo "Image $IMAGE exists in the remote repository."

--- a/tools/compare_versions/prepare_image.sh
+++ b/tools/compare_versions/prepare_image.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# This script checks for the image in the remote repo
+# and if it not there triggers the image build in the
+# main Qdrant repo for the specified version and waits
+# until the image is available in the remote repository.
+#
+# Usage: export QDRANT_VERSION="ghcr/dev" && ./prepare_image.sh
+
 
 QDRANT_VERSION=${QDRANT_VERSION:-"ghcr/dev"}
 

--- a/tools/compare_versions/prepare_image.sh
+++ b/tools/compare_versions/prepare_image.sh
@@ -50,7 +50,7 @@ curl -L \
   -H "Authorization: Bearer ${BEARER_TOKEN}" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   https://api.github.com/repos/qdrant/qdrant/dispatches \
-  -d "{\"event_type\": \"$EVENT_TYPE\", \"client_payload\": {\"version\": \"$QDRANT_VERSION\"}}"
+  -d "{\"event_type\": \"$EVENT_TYPE\", \"client_payload\": {\"version\": \"$QDRANT_VERSION\", \"triggered\": true}}"
 
 echo "Wait for the image to appear in the remote repository..."
 counter=0

--- a/tools/compare_versions/prepare_image.sh
+++ b/tools/compare_versions/prepare_image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script checks for the image in the remote repo
-# and if it not there triggers the image build in the
+# and if it is not there triggers the image build in the
 # main Qdrant repo for the specified version and waits
 # until the image is available in the remote repository.
 #

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -50,6 +50,8 @@ export VM_RSS_MEMORY_USAGE_FILE=$(ls -t results/vm-rss-memory-usage-*.txt | head
 export RSS_ANON_MEMORY_USAGE_FILE=$(ls -t results/rss-anon-memory-usage-*.txt | head -n 1)
 export ROOT_API_RESPONSE_FILE=$(ls -t results/root-api-*.json | head -n 1)
 
+export IS_CI_RUN="true"
+
 if [[ "$BENCHMARK_STRATEGY" == "parallel" ]]; then
   bash -x "${SCRIPT_PATH}/upload_parallel_results_postgres.sh"
 else

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -31,6 +31,8 @@ POSTGRES_TABLE=${POSTGRES_TABLE:-"benchmark_parallel_search_upload"}
 QDRANT_VERSION=${QDRANT_VERSION:-"dev"}
 DATASETS=${DATASETS:-"laion-small-clip"}
 
+IS_CI_RUN=${IS_CI_RUN:-"false"}
+
 if [[ "$BENCHMARK_STRATEGY" != "parallel" ]]; then
   echo "BENCHMARK_STRATEGY is not parallel"
   exit 1
@@ -90,3 +92,15 @@ INSERT INTO ${POSTGRES_TABLE} (engine, branch, commit, dataset, measure_timestam
 VALUES ('qdrant-ci', '${QDRANT_VERSION}', '${QDRANT_COMMIT}', '${DATASETS}', '${MEASURE_TIMESTAMP}', ${UPLOAD_TIME}, ${INDEXING_TIME}, ${RPS}, ${MEAN_PRECISIONS}, ${P95_TIME}, ${P99_TIME}, ${SEARCH_TIME}, ${NO_UPSERT_SEARCH_TIME});
 "
 
+if [[ "$IS_CI_RUN" == "true" ]]; then
+  echo "rps=${RPS}" >> "$GITHUB_OUTPUT"
+  echo "mean_precisions=${MEAN_PRECISIONS}" >> "$GITHUB_OUTPUT"
+  echo "p95_time=${P95_TIME}" >> "$GITHUB_OUTPUT"
+  echo "p99_time=${P99_TIME}" >> "$GITHUB_OUTPUT"
+
+  echo "search_time=${SEARCH_TIME}" >> "$GITHUB_OUTPUT"
+  echo "no_upsert_search_time=${NO_UPSERT_SEARCH_TIME}" >> "$GITHUB_OUTPUT"
+
+  echo "upload_time=${UPLOAD_TIME}" >> "$GITHUB_OUTPUT"
+  echo "indexing_time=${INDEXING_TIME}" >> "$GITHUB_OUTPUT"
+fi

--- a/tools/upload_results_postgres.sh
+++ b/tools/upload_results_postgres.sh
@@ -33,6 +33,8 @@ POSTGRES_TABLE=${POSTGRES_TABLE:-"benchmark"}
 QDRANT_VERSION=${QDRANT_VERSION:-"dev"}
 DATASETS=${DATASETS:-"laion-small-clip"}
 
+IS_CI_RUN=${IS_CI_RUN:-"false"}
+
 if [[ "$BENCHMARK_STRATEGY" == "collection-reload" ]]; then
   if [[ -z "$TELEMETRY_API_RESPONSE_FILE" ]]; then
     echo "TELEMETRY_API_RESPONSE_FILE is not set"
@@ -102,3 +104,17 @@ INSERT INTO ${POSTGRES_TABLE} (engine, branch, commit, dataset, measure_timestam
 VALUES ('qdrant-ci', '${QDRANT_VERSION}', '${QDRANT_COMMIT}', '${DATASETS}', '${MEASURE_TIMESTAMP}', ${UPLOAD_TIME}, ${INDEXING_TIME}, ${RPS}, ${MEAN_PRECISIONS}, ${P95_TIME}, ${P99_TIME}, ${VM_RSS_MEMORY_USAGE}, ${RSS_ANON_MEMORY_USAGE}, ${COLLECTION_LOAD_TIME});
 "
 
+if [[ "$IS_CI_RUN" == "true" ]]; then
+  echo "collection_load_time=${COLLECTION_LOAD_TIME}" >> "$GITHUB_OUTPUT"
+
+  echo "rps=${RPS}" >> "$GITHUB_OUTPUT"
+  echo "mean_precisions=${MEAN_PRECISIONS}" >> "$GITHUB_OUTPUT"
+  echo "p95_time=${P95_TIME}" >> "$GITHUB_OUTPUT"
+  echo "p99_time=${P99_TIME}" >> "$GITHUB_OUTPUT"
+
+  echo "vm_rss_memory_usage=${VM_RSS_MEMORY_USAGE}" >> "$GITHUB_OUTPUT"
+  echo "rss_anon_memory_usage=${RSS_ANON_MEMORY_USAGE}" >> "$GITHUB_OUTPUT"
+
+  echo "upload_time=${UPLOAD_TIME}" >> "$GITHUB_OUTPUT"
+  echo "indexing_time=${INDEXING_TIME}" >> "$GITHUB_OUTPUT"
+fi

--- a/tools/upload_results_postgres.sh
+++ b/tools/upload_results_postgres.sh
@@ -91,8 +91,8 @@ else
   INDEXING_TIME=$(jq -r '.results.total_time' "$UPLOAD_RESULTS_FILE")
 fi
 
-VM_RSS_MEMORY_USAGE=$(cat "$VM_RSS_MEMORY_USAGE_FILE")
-RSS_ANON_MEMORY_USAGE=$(cat "$RSS_ANON_MEMORY_USAGE_FILE")
+VM_RSS_MEMORY_USAGE=$(cat "$VM_RSS_MEMORY_USAGE_FILE" | tr -d '[:space:]')
+RSS_ANON_MEMORY_USAGE=$(cat "$RSS_ANON_MEMORY_USAGE_FILE" | tr -d '[:space:]')
 
 QDRANT_COMMIT=$(jq -r '.commit' "$ROOT_API_RESPONSE_FILE")
 


### PR DESCRIPTION
A new workflow to compare 2 qdrant versions in 1 run:
1. check if there are images for the provided versions
2. if there is no image -> trigger image build workflow in qdrant repo and wait for image to appear in remote repo for up to 150 minutes
3. if image is ok -> proceed to benchmark execution
4. in the end compare results between to versions

Note: if the workflow triggered image build in the main repo and that triggered workflow is queued, then there is nothing we can do about it. If the triggered workflow took longer than 150 minutes the original job will fail