### PR TITLE
Use find instead of ls to search files

### DIFF
--- a/tools/run_client_script.sh
+++ b/tools/run_client_script.sh
@@ -61,7 +61,7 @@ if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "upload" ]]; t
 fi
 
 if [[ "$EXPERIMENT_MODE" == "full" ]] || [[ "$EXPERIMENT_MODE" == "search" ]]; then
-  SEARCH_RESULT_FILE=$(ssh -o ServerAliveInterval=10 -o ServerAliveCountMax=10 "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "ls -t results/*-search-*.json | head -n 1")
+  SEARCH_RESULT_FILE=$(ssh -o ServerAliveInterval=10 -o ServerAliveCountMax=10 "${SERVER_USERNAME}@${IP_OF_THE_CLIENT}" "find results/ -type f -name '*-search-*.json' -printf '%T@ %p\n' | sort -nr | head -n 1 | cut -d' ' -f2-")
   result_files_arr+=("$SEARCH_RESULT_FILE")
 fi
 


### PR DESCRIPTION
Fix `argument list too long` error:

https://github.com/qdrant/vector-db-benchmark/actions/runs/14294219494/job/40060489525