### PR TITLE
Use boolean input type in workflow input for toggling all feature flags

### DIFF
--- a/.github/workflows/manual-benchmark.yaml
+++ b/.github/workflows/manual-benchmark.yaml
@@ -14,7 +14,8 @@ on:
             description: "Engine config to benchmark"
             default: qdrant-continuous-benchmark
         feature_flags_all:
-            description: "Enable all feature flags (true|false, false by default)"
+            type: boolean
+            description: "Enable all feature flags (false by default)"
             default: false
 
 

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -20,10 +20,12 @@ on:
             description: "Engine config to benchmark"
             default: qdrant-continuous-benchmark
         feature_flags_all_version_1:
-            description: "Enable all feature flags (true|false, false by default), version 1"
+            type: boolean
+            description: "Enable all feature flags (false by default), version 1"
             default: false
         feature_flags_all_version_2:
-            description: "Enable all feature flags (true|false, false by default), version 2"
+            type: boolean
+            description: "Enable all feature flags (false by default), version 2"
             default: false
 
 jobs:


### PR DESCRIPTION
Follow-up on <https://github.com/qdrant/vector-db-benchmark/pull/241>, <https://github.com/qdrant/vector-db-benchmark/pull/243>

We can use a boolean input to show a checkbox, that's probably a bit nicer.

Docs: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callinputsinput_idtype

As far as I understand this still produces 'true' or 'false'