### PR TITLE
Add CPU stats into monitoring

### DIFF
--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -38,6 +38,9 @@ jobs:
 
             declare -A DATASET_TO_ENGINE
             DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark${SUFFIX}"
+            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector${SUFFIX}"
+            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark${SUFFIX}"
+            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark${SUFFIX}"
 
             set +e
 
@@ -60,233 +63,233 @@ jobs:
       - name: Fail job if any of the benches failed
         if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
         run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-#  runTenantsBenchmark:
-#    runs-on: ubuntu-latest
-#    needs: runBenchmark
-#    if: ${{ always() }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Benches
-#        id: benches
-#        run: |
-#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#            export WITH_PAYLOAD=${{ inputs.with_payload }}
-#            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
-#
-#            bash -x tools/setup_ci.sh
-#
-#            set +e
-#
-#            # Benchmark filtered search by tenants with mem limitation
-#
-#            export ENGINE_NAME="qdrant-all-on-disk-scalar-q${SUFFIX}"
-#            export DATASETS="random-768-100-tenants"
-#            export BENCHMARK_STRATEGY="tenants"
-#            export CONTAINER_MEM_LIMIT=160mb
-#
-#            # Benchmark the dev branch:
-#            export QDRANT_VERSION=ghcr/dev
-#            export QDRANT__FEATURE_FLAGS__ALL=true
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            # Benchmark the master branch:
-#            export QDRANT_VERSION=docker/master
-#            export QDRANT__FEATURE_FLAGS__ALL=false
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            set -e
-#      - name: Fail job if any of the benches failed
-#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-#        run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-#  runParallelBenchmark:
-#    runs-on: ubuntu-latest
-#    needs: runTenantsBenchmark
-#    if: ${{ always() }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: webfactory/ssh-agent@v0.8.0
-#        with:
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#      - name: Benches
-#        id: benches
-#        run: |
-#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-#            export WITH_PAYLOAD=${{ inputs.with_payload }}
-#            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
-#
-#            bash -x tools/setup_ci.sh
-#
-#            set +e
-#
-#            # Benchmark parallel search&upload
-#
-#            export ENGINE_NAME="qdrant-continuous-benchmark${SUFFIX}"
-#            export DATASETS="laion-small-clip"
-#            export BENCHMARK_STRATEGY="parallel"
-#            export POSTGRES_TABLE="benchmark_parallel_search_upload"
-#
-#            # Benchmark the dev branch:
-#            export QDRANT_VERSION=ghcr/dev
-#            export QDRANT__FEATURE_FLAGS__ALL=true
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            # Benchmark the master branch:
-#            export QDRANT_VERSION=docker/master
-#            export QDRANT__FEATURE_FLAGS__ALL=false
-#            timeout 30m bash -x tools/run_ci.sh
-#
-#            set -e
-#      - name: Fail job if any of the benches failed
-#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-#        run: exit 1
-#      - name: Send Notification
-#        if: failure() || cancelled()
-#        uses: slackapi/slack-github-action@v1.26.0
-#        with:
-#          payload: |
-#            {
-#              "text": "CI benchmarks (runParallelBenchmark) run status: ${{ job.status }}",
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "CI benchmarks (runParallelBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runTenantsBenchmark:
+    runs-on: ubuntu-latest
+    needs: runBenchmark
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            export WITH_PAYLOAD=${{ inputs.with_payload }}
+            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
+
+            bash -x tools/setup_ci.sh
+
+            set +e
+
+            # Benchmark filtered search by tenants with mem limitation
+
+            export ENGINE_NAME="qdrant-all-on-disk-scalar-q${SUFFIX}"
+            export DATASETS="random-768-100-tenants"
+            export BENCHMARK_STRATEGY="tenants"
+            export CONTAINER_MEM_LIMIT=160mb
+
+            # Benchmark the dev branch:
+            export QDRANT_VERSION=ghcr/dev
+            export QDRANT__FEATURE_FLAGS__ALL=true
+            timeout 30m bash -x tools/run_ci.sh
+
+            # Benchmark the master branch:
+            export QDRANT_VERSION=docker/master
+            export QDRANT__FEATURE_FLAGS__ALL=false
+            timeout 30m bash -x tools/run_ci.sh
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  runParallelBenchmark:
+    runs-on: ubuntu-latest
+    needs: runTenantsBenchmark
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Benches
+        id: benches
+        run: |
+            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+            export WITH_PAYLOAD=${{ inputs.with_payload }}
+            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
+
+            bash -x tools/setup_ci.sh
+
+            set +e
+
+            # Benchmark parallel search&upload
+
+            export ENGINE_NAME="qdrant-continuous-benchmark${SUFFIX}"
+            export DATASETS="laion-small-clip"
+            export BENCHMARK_STRATEGY="parallel"
+            export POSTGRES_TABLE="benchmark_parallel_search_upload"
+
+            # Benchmark the dev branch:
+            export QDRANT_VERSION=ghcr/dev
+            export QDRANT__FEATURE_FLAGS__ALL=true
+            timeout 30m bash -x tools/run_ci.sh
+
+            # Benchmark the master branch:
+            export QDRANT_VERSION=docker/master
+            export QDRANT__FEATURE_FLAGS__ALL=false
+            timeout 30m bash -x tools/run_ci.sh
+
+            set -e
+      - name: Fail job if any of the benches failed
+        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+        run: exit 1
+      - name: Send Notification
+        if: failure() || cancelled()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "CI benchmarks (runParallelBenchmark) run status: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CI benchmarks (runParallelBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -60,54 +60,54 @@ jobs:
       - name: Fail job if any of the benches failed
         if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
         run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks (runBenchmark) run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks (runBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 #  runTenantsBenchmark:
 #    runs-on: ubuntu-latest
 #    needs: runBenchmark

--- a/.github/workflows/continuous-benchmark.yaml
+++ b/.github/workflows/continuous-benchmark.yaml
@@ -38,9 +38,6 @@ jobs:
 
             declare -A DATASET_TO_ENGINE
             DATASET_TO_ENGINE["laion-small-clip"]="qdrant-continuous-benchmark${SUFFIX}"
-            DATASET_TO_ENGINE["msmarco-sparse-100K"]="qdrant-sparse-vector${SUFFIX}"
-            DATASET_TO_ENGINE["h-and-m-2048-angular-filters"]="qdrant-continuous-benchmark${SUFFIX}"
-            DATASET_TO_ENGINE["dbpedia-openai-100K-1536-angular"]="qdrant-bq-continuous-benchmark${SUFFIX}"
 
             set +e
 
@@ -111,185 +108,185 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  runTenantsBenchmark:
-    runs-on: ubuntu-latest
-    needs: runBenchmark
-    if: ${{ always() }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Benches
-        id: benches
-        run: |
-            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-            export WITH_PAYLOAD=${{ inputs.with_payload }}
-            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
-
-            bash -x tools/setup_ci.sh
-
-            set +e
-
-            # Benchmark filtered search by tenants with mem limitation
-
-            export ENGINE_NAME="qdrant-all-on-disk-scalar-q${SUFFIX}"
-            export DATASETS="random-768-100-tenants"
-            export BENCHMARK_STRATEGY="tenants"
-            export CONTAINER_MEM_LIMIT=160mb
-
-            # Benchmark the dev branch:
-            export QDRANT_VERSION=ghcr/dev
-            export QDRANT__FEATURE_FLAGS__ALL=true
-            timeout 30m bash -x tools/run_ci.sh
-
-            # Benchmark the master branch:
-            export QDRANT_VERSION=docker/master
-            export QDRANT__FEATURE_FLAGS__ALL=false
-            timeout 30m bash -x tools/run_ci.sh
-
-            set -e
-      - name: Fail job if any of the benches failed
-        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-        run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  runParallelBenchmark:
-    runs-on: ubuntu-latest
-    needs: runTenantsBenchmark
-    if: ${{ always() }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Benches
-        id: benches
-        run: |
-            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
-            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
-            export WITH_PAYLOAD=${{ inputs.with_payload }}
-            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
-
-            bash -x tools/setup_ci.sh
-
-            set +e
-
-            # Benchmark parallel search&upload
-
-            export ENGINE_NAME="qdrant-continuous-benchmark${SUFFIX}"
-            export DATASETS="laion-small-clip"
-            export BENCHMARK_STRATEGY="parallel"
-            export POSTGRES_TABLE="benchmark_parallel_search_upload"
-
-            # Benchmark the dev branch:
-            export QDRANT_VERSION=ghcr/dev
-            export QDRANT__FEATURE_FLAGS__ALL=true
-            timeout 30m bash -x tools/run_ci.sh
-
-            # Benchmark the master branch:
-            export QDRANT_VERSION=docker/master
-            export QDRANT__FEATURE_FLAGS__ALL=false
-            timeout 30m bash -x tools/run_ci.sh
-
-            set -e
-      - name: Fail job if any of the benches failed
-        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
-        run: exit 1
-      - name: Send Notification
-        if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI benchmarks (runParallelBenchmark) run status: ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI benchmarks (runParallelBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#  runTenantsBenchmark:
+#    runs-on: ubuntu-latest
+#    needs: runBenchmark
+#    if: ${{ always() }}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: webfactory/ssh-agent@v0.8.0
+#        with:
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#      - name: Benches
+#        id: benches
+#        run: |
+#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+#            export WITH_PAYLOAD=${{ inputs.with_payload }}
+#            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
+#
+#            bash -x tools/setup_ci.sh
+#
+#            set +e
+#
+#            # Benchmark filtered search by tenants with mem limitation
+#
+#            export ENGINE_NAME="qdrant-all-on-disk-scalar-q${SUFFIX}"
+#            export DATASETS="random-768-100-tenants"
+#            export BENCHMARK_STRATEGY="tenants"
+#            export CONTAINER_MEM_LIMIT=160mb
+#
+#            # Benchmark the dev branch:
+#            export QDRANT_VERSION=ghcr/dev
+#            export QDRANT__FEATURE_FLAGS__ALL=true
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            # Benchmark the master branch:
+#            export QDRANT_VERSION=docker/master
+#            export QDRANT__FEATURE_FLAGS__ALL=false
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            set -e
+#      - name: Fail job if any of the benches failed
+#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+#        run: exit 1
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks (runTenantsBenchmark) run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks (runTenantsBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#  runParallelBenchmark:
+#    runs-on: ubuntu-latest
+#    needs: runTenantsBenchmark
+#    if: ${{ always() }}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: webfactory/ssh-agent@v0.8.0
+#        with:
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#      - name: Benches
+#        id: benches
+#        run: |
+#            export HCLOUD_TOKEN=${{ secrets.HCLOUD_TOKEN }}
+#            export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+#            export POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+#            export WITH_PAYLOAD=${{ inputs.with_payload }}
+#            export SUFFIX=$([ "${WITH_PAYLOAD}" = "true" ] && echo "-with-payload" || echo "")
+#
+#            bash -x tools/setup_ci.sh
+#
+#            set +e
+#
+#            # Benchmark parallel search&upload
+#
+#            export ENGINE_NAME="qdrant-continuous-benchmark${SUFFIX}"
+#            export DATASETS="laion-small-clip"
+#            export BENCHMARK_STRATEGY="parallel"
+#            export POSTGRES_TABLE="benchmark_parallel_search_upload"
+#
+#            # Benchmark the dev branch:
+#            export QDRANT_VERSION=ghcr/dev
+#            export QDRANT__FEATURE_FLAGS__ALL=true
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            # Benchmark the master branch:
+#            export QDRANT_VERSION=docker/master
+#            export QDRANT__FEATURE_FLAGS__ALL=false
+#            timeout 30m bash -x tools/run_ci.sh
+#
+#            set -e
+#      - name: Fail job if any of the benches failed
+#        if: steps.benches.outputs.failed == 'error' || steps.benches.outputs.failed == 'timeout'
+#        run: exit 1
+#      - name: Send Notification
+#        if: failure() || cancelled()
+#        uses: slackapi/slack-github-action@v1.26.0
+#        with:
+#          payload: |
+#            {
+#              "text": "CI benchmarks (runParallelBenchmark) run status: ${{ job.status }}",
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "CI benchmarks (runParallelBenchmark) failed because of *${{ steps.benches.outputs.failed }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Qdrant version: *${{ steps.benches.outputs.qdrant_version }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Engine: *${{ steps.benches.outputs.engine_name }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Dataset: *${{ steps.benches.outputs.dataset }}*."
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "View the results <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.CI_ALERTS_CHANNEL_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -167,6 +167,7 @@ jobs:
           res_p99_time=$(compare "p99_time" "${{ needs.runBenchmarkForVersion1.outputs.p99_time }}" "${{ needs.runBenchmarkForVersion2.outputs.p99_time }}")
           res_vm_rss_memory_usage=$(compare "vm_rss_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.vm_rss_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.vm_rss_memory_usage }}")
           res_rss_anon_memory_usage=$(compare "rss_anon_memory_usage" "${{ needs.runBenchmarkForVersion1.outputs.rss_anon_memory_usage }}" "${{ needs.runBenchmarkForVersion2.outputs.rss_anon_memory_usage }}")
+          res_cpu_usage=$(compare "cpu_usage" "${{ needs.runBenchmarkForVersion1.outputs.cpu }}" "${{ needs.runBenchmarkForVersion2.outputs.cpu }}")
           res_upload_time=$(compare "upload_time" "${{ needs.runBenchmarkForVersion1.outputs.upload_time }}" "${{ needs.runBenchmarkForVersion2.outputs.upload_time }}")
           res_indexing_time=$(compare "indexing_time" "${{ needs.runBenchmarkForVersion1.outputs.indexing_time }}" "${{ needs.runBenchmarkForVersion2.outputs.indexing_time }}")
 
@@ -179,6 +180,7 @@ jobs:
           echo "| p95_time              | ${{ needs.runBenchmarkForVersion1.outputs.p95_time }} | ${{ needs.runBenchmarkForVersion2.outputs.p95_time }} | ${res_p95_time} |" >> $GITHUB_STEP_SUMMARY
           echo "| p99_time              | ${{ needs.runBenchmarkForVersion1.outputs.p99_time }} | ${{ needs.runBenchmarkForVersion2.outputs.p99_time }} | ${res_p99_time} |" >> $GITHUB_STEP_SUMMARY
           echo "| vm_rss_memory_usage   | ${{ needs.runBenchmarkForVersion1.outputs.vm_rss_memory_usage }} | ${{ needs.runBenchmarkForVersion2.outputs.vm_rss_memory_usage }} | ${res_vm_rss_memory_usage} |" >> $GITHUB_STEP_SUMMARY
-          echo "| rss_anon_memory_usage  | ${{ needs.runBenchmarkForVersion1.outputs.rss_anon_memory_usage }} | ${{ needs.runBenchmarkForVersion2.outputs.rss_anon_memory_usage }} | ${res_rss_anon_memory_usage} |" >> $GITHUB_STEP_SUMMARY
+          echo "| rss_anon_memory_usage | ${{ needs.runBenchmarkForVersion1.outputs.rss_anon_memory_usage }} | ${{ needs.runBenchmarkForVersion2.outputs.rss_anon_memory_usage }} | ${res_rss_anon_memory_usage} |" >> $GITHUB_STEP_SUMMARY
+          echo "| cpu                   | ${{ needs.runBenchmarkForVersion1.outputs.cpu }} | ${{ needs.runBenchmarkForVersion2.outputs.cpu }} | ${res_cpu_usage} |" >> $GITHUB_STEP_SUMMARY
           echo "| upload_time           | ${{ needs.runBenchmarkForVersion1.outputs.upload_time }} | ${{ needs.runBenchmarkForVersion2.outputs.upload_time }} | ${res_upload_time} |" >> $GITHUB_STEP_SUMMARY
           echo "| indexing_time         | ${{ needs.runBenchmarkForVersion1.outputs.indexing_time }} | ${{ needs.runBenchmarkForVersion2.outputs.indexing_time }} | ${res_indexing_time} |" >> $GITHUB_STEP_SUMMARY

--- a/tools/qdrant_collect_cpu_usage.sh
+++ b/tools/qdrant_collect_cpu_usage.sh
@@ -17,6 +17,8 @@ BENCH_SERVER_NAME=${SERVER_NAME:-"benchmark-server-1"}
 IP_OF_THE_SERVER=$(bash "${SCRIPT_PATH}/${CLOUD_NAME}/get_public_ip.sh" "$BENCH_SERVER_NAME")
 
 UTIME=$(ssh -tt -o ServerAliveInterval=10 -o ServerAliveCountMax=10 "${SERVER_USERNAME}@${IP_OF_THE_SERVER}" "cat /proc/\$(pidof qdrant)/stat | awk '{print \$14}'")
+# Clean up any whitespace characters
+UTIME=$(echo "$UTIME" | tr -d '[:space:]')
 
 CURRENT_DATE=$(date +%Y-%m-%d-%H-%M-%S)
 
@@ -25,12 +27,13 @@ mkdir -p results/cpu
 if [[ "$MODE" == "end" ]]; then
   echo "Calculate CPU usage (seconds) over period of time"
   UTIME_FILE=$(ls -t results/cpu/utime-*.txt | head -n 1)
-  UTIME_START=$(head -n 1 "$UTIME_FILE")
+  UTIME_START=$(cat "$UTIME_FILE" | tr -d '[:space:]')
   echo "$UTIME" >> "${UTIME_FILE}"
   CPU=$(echo "scale=2; ($UTIME - $UTIME_START) / 100" | bc)
-  echo "$CPU" > results/cpu/cpu-usage-"${CURRENT_DATE}".txt
+  echo "$CPU" > "./results/cpu/cpu-usage-${CURRENT_DATE}.txt"
 elif [[ "$MODE" == "start" ]]; then
-  echo "$UTIME" >> "./results/cpu/utime-${CURRENT_DATE}.txt"
+  echo "Store utime start value in ./results/cpu/utime-${CURRENT_DATE}.txt"
+  echo "$UTIME" > "./results/cpu/utime-${CURRENT_DATE}.txt"
 else
   echo "Unknown mode: $MODE"
   exit 1

--- a/tools/qdrant_collect_cpu_usage.sh
+++ b/tools/qdrant_collect_cpu_usage.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+PS4='ts=$(date "+%Y-%m-%dT%H:%M:%SZ") level=DEBUG line=$LINENO file=$BASH_SOURCE '
+set -euo pipefail
+
+# Examples: start or end
+MODE=$1
+
+CLOUD_NAME=${CLOUD_NAME:-"hetzner"}
+SERVER_USERNAME=${SERVER_USERNAME:-"root"}
+
+SCRIPT=$(realpath "$0")
+SCRIPT_PATH=$(dirname "$SCRIPT")
+
+BENCH_SERVER_NAME=${SERVER_NAME:-"benchmark-server-1"}
+
+IP_OF_THE_SERVER=$(bash "${SCRIPT_PATH}/${CLOUD_NAME}/get_public_ip.sh" "$BENCH_SERVER_NAME")
+
+UTIME=$(ssh -tt -o ServerAliveInterval=10 -o ServerAliveCountMax=10 "${SERVER_USERNAME}@${IP_OF_THE_SERVER}" "cat /proc/\$(pidof qdrant)/stat | awk '{print \$14}'")
+
+CURRENT_DATE=$(date +%Y-%m-%d-%H-%M-%S)
+
+mkdir -p results/cpu
+
+if [[ "$MODE" == "end" ]]; then
+  echo "Calculate CPU usage (seconds) over period of time"
+  UTIME_FILE=$(ls -t results/cpu/utime-*.txt | head -n 1)
+  UTIME_START=$(head -n 1 "$UTIME_FILE")
+  echo "$UTIME" >> "${UTIME_FILE}"
+  CPU=$(echo "scale=2; ($UTIME - $UTIME_START) / 100" | bc)
+  echo "$CPU" > results/cpu/cpu-usage-"${CURRENT_DATE}".txt
+elif [[ "$MODE" == "start" ]]; then
+  echo "$UTIME" >> "./results/cpu/utime-${CURRENT_DATE}.txt"
+else
+  echo "Unknown mode: $MODE"
+  exit 1
+fi

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -24,6 +24,7 @@ trap 'handle_term' TERM
 
 # Script, that runs benchmark within the GitHub Actions CI environment
 
+# Possible values for BENCHMARK_STRATEGY: default, tenants, parallel and collection-reload
 BENCHMARK_STRATEGY=${BENCHMARK_STRATEGY:-"default"}
 
 SCRIPT=$(realpath "$0")

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -38,11 +38,12 @@ if [[ "$BENCHMARK_STRATEGY" == "collection-reload" ]]; then
   export TELEMETRY_API_RESPONSE_FILE=$(ls -t results/telemetry-api-*.json | head -n 1)
 else
   # any other strategies are considered to have search & upload results
+  export TELEMETRY_API_RESPONSE_FILE=$(ls -t results/telemetry-api-*.json | head -n 1)
   export SEARCH_RESULTS_FILE=$(find results/ -maxdepth 1 -type f -name '*-search-*.json' -printf '%T@ %p\n' | sort -nr | head -n 1 | cut -d' ' -f2-)
   export UPLOAD_RESULTS_FILE=$(find results/ -maxdepth 1 -type f -name '*-upload-*.json' -printf '%T@ %p\n' | sort -nr | head -n 1 | cut -d' ' -f2-)
 
   if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
-    export CPU_USAGE_FILE=$(ls -t results/cpu/cpu-usage-*.json | head -n 1)
+    export CPU_USAGE_FILE=$(ls -t results/cpu/cpu-usage-*.txt | head -n 1)
   fi
 
   if [[ "$BENCHMARK_STRATEGY" == "parallel" ]]; then

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -41,6 +41,10 @@ else
   export SEARCH_RESULTS_FILE=$(find results/ -maxdepth 1 -type f -name '*-search-*.json' -printf '%T@ %p\n' | sort -nr | head -n 1 | cut -d' ' -f2-)
   export UPLOAD_RESULTS_FILE=$(find results/ -maxdepth 1 -type f -name '*-upload-*.json' -printf '%T@ %p\n' | sort -nr | head -n 1 | cut -d' ' -f2-)
 
+  if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
+    export CPU_USAGE_FILE=$(ls -t results/cpu/cpu-usage-*.json | head -n 1)
+  fi
+
   if [[ "$BENCHMARK_STRATEGY" == "parallel" ]]; then
     export PARALLEL_UPLOAD_RESULTS_FILE=$(ls -t results/parallel/*-upload-*.json | head -n 1)
     export PARALLEL_SEARCH_RESULTS_FILE=$(ls -t results/parallel/*-search-*.json | head -n 1)

--- a/tools/run_ci.sh
+++ b/tools/run_ci.sh
@@ -25,7 +25,7 @@ trap 'handle_term' TERM
 # Script, that runs benchmark within the GitHub Actions CI environment
 
 # Possible values for BENCHMARK_STRATEGY: default, tenants, parallel and collection-reload
-BENCHMARK_STRATEGY=${BENCHMARK_STRATEGY:-"default"}
+export BENCHMARK_STRATEGY=${BENCHMARK_STRATEGY:-"default"}
 
 SCRIPT=$(realpath "$0")
 SCRIPT_PATH=$(dirname "$SCRIPT")

--- a/tools/run_remote_benchmark.sh
+++ b/tools/run_remote_benchmark.sh
@@ -44,7 +44,11 @@ case "$BENCHMARK_STRATEGY" in
 
   bash -x "${SCRIPT_PATH}/run_server_container.sh" "$SERVER_CONTAINER_NAME"
 
+  bash -x "${SCRIPT_PATH}/qdrant_collect_cpu_usage.sh" "start"
+
   bash -x "${SCRIPT_PATH}/run_client_script.sh"
+
+  bash -x "${SCRIPT_PATH}/qdrant_collect_cpu_usage.sh" "end"
 
   bash -x "${SCRIPT_PATH}/qdrant_collect_stats.sh" "$SERVER_CONTAINER_NAME"
   ;;

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -94,6 +94,7 @@ UPLOAD_TIME=$(jq -r '.results.upload_time' "$PARALLEL_UPLOAD_RESULTS_FILE")
 INDEXING_TIME=$(jq -r '.results.total_time' "$PARALLEL_UPLOAD_RESULTS_FILE")
 
 if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
+  # Only this strategy produces cpu usage results files
   CPU=$(cat "$CPU_USAGE_FILE" | tr -d '[:space:]')
 fi
 CPU_TELEMETRY=$(jq -r '.result.hardware.collection_data.benchmark.cpu' "$TELEMETRY_API_RESPONSE_FILE")

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -93,7 +93,7 @@ NO_UPSERT_SEARCH_TIME=$(jq -r '.results.total_time' "$SEARCH_RESULT_FILE")
 UPLOAD_TIME=$(jq -r '.results.upload_time' "$PARALLEL_UPLOAD_RESULTS_FILE")
 INDEXING_TIME=$(jq -r '.results.total_time' "$PARALLEL_UPLOAD_RESULTS_FILE")
 
-if [[ "$BENCHMARK_STRATEGY" != "default" ]]; then
+if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
   CPU=$(cat "$CPU_USAGE_FILE" | tr -d '[:space:]')
 fi
 CPU_TELEMETRY=$(jq -r '.result.hardware.collection_data.benchmark.cpu' "$TELEMETRY_API_RESPONSE_FILE")

--- a/tools/upload_parallel_results_postgres.sh
+++ b/tools/upload_parallel_results_postgres.sh
@@ -65,7 +65,7 @@ if [[ -z "$ROOT_API_RESPONSE_FILE" ]]; then
   exit 1
 fi
 
-if [[ "$BENCHMARK_STRATEGY" != "default" ]]; then
+if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
   if [[ -z "$CPU_USAGE_FILE" ]]; then
     echo "CPU_USAGE_FILE is not set"
     exit 1

--- a/tools/upload_results_postgres.sh
+++ b/tools/upload_results_postgres.sh
@@ -71,7 +71,7 @@ if [[ -z "$ROOT_API_RESPONSE_FILE" ]]; then
   exit 1
 fi
 
-if [[ "$BENCHMARK_STRATEGY" != "default" ]]; then
+if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
   if [[ -z "$CPU_USAGE_FILE" ]]; then
     echo "CPU_USAGE_FILE is not set"
     exit 1

--- a/tools/upload_results_postgres.sh
+++ b/tools/upload_results_postgres.sh
@@ -107,6 +107,7 @@ VM_RSS_MEMORY_USAGE=$(cat "$VM_RSS_MEMORY_USAGE_FILE" | tr -d '[:space:]')
 RSS_ANON_MEMORY_USAGE=$(cat "$RSS_ANON_MEMORY_USAGE_FILE" | tr -d '[:space:]')
 
 if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
+  # Only this strategy produces cpu usage results files
   CPU=$(cat "$CPU_USAGE_FILE" | tr -d '[:space:]')
 fi
 CPU_TELEMETRY=$(jq -r '.result.hardware.collection_data.benchmark.cpu' "$TELEMETRY_API_RESPONSE_FILE")

--- a/tools/upload_results_postgres.sh
+++ b/tools/upload_results_postgres.sh
@@ -106,7 +106,7 @@ fi
 VM_RSS_MEMORY_USAGE=$(cat "$VM_RSS_MEMORY_USAGE_FILE" | tr -d '[:space:]')
 RSS_ANON_MEMORY_USAGE=$(cat "$RSS_ANON_MEMORY_USAGE_FILE" | tr -d '[:space:]')
 
-if [[ "$BENCHMARK_STRATEGY" != "default" ]]; then
+if [[ "$BENCHMARK_STRATEGY" == "default" ]]; then
   CPU=$(cat "$CPU_USAGE_FILE" | tr -d '[:space:]')
 fi
 CPU_TELEMETRY=$(jq -r '.result.hardware.collection_data.benchmark.cpu' "$TELEMETRY_API_RESPONSE_FILE")


### PR DESCRIPTION
Accumulate CPU usage stats for `default` (!) benchmark strategy. Currently there are 2 sources:
1. telemetry reports from qdrant 
2. `utime` obtained from server machine (calculated as difference between utime before benchmark and utime after the benchmark, divided by 100 to get number of seconds).

https://docs.rs/procfs/latest/procfs/process/struct.Stat.html#structfield.utime 

Example run: 
https://github.com/qdrant/vector-db-benchmark/actions/runs/14702755957