### PR TITLE
Add re-try logic to ssh sync and check

### DIFF
--- a/tools/sync_servers.sh
+++ b/tools/sync_servers.sh
@@ -2,5 +2,13 @@
 
 PROJECT_PATH=$(realpath "$(dirname "$0")/..")
 
-rsync -e "ssh -o ServerAliveInterval=10 -o ServerAliveCountMax=10" -avP --mkpath\
-   "$PROJECT_PATH/engine/servers/" $1:./projects/vector-db-benchmark/engine/servers/
+max_retries=5
+retry_delay=5
+for ((i=1; i<=max_retries; i++)); do
+    if rsync -e "ssh -o ConnectTimeout=30 -o ServerAliveInterval=10 -o ServerAliveCountMax=10" \
+       -avP --mkpath "$PROJECT_PATH/engine/servers/" "$1:./projects/vector-db-benchmark/engine/servers/"; then
+        break
+    fi
+    echo "rsync failed (attempt $i/$max_retries), retrying in ${retry_delay}s..."
+    sleep $retry_delay
+done


### PR DESCRIPTION
Attempt to fix intermittent SSH connection failures (kex_exchange_identification: Connection reset by peer). They are probably caused by server rate limiting or network issues.

* Add retry loop (5 attempts) with ConnectTimeout=30 for rsync operations 
* Add retry loop (10 attempts) with ConnectTimeout=10 for SSH readiness checks
