### PR TITLE
Fix concurrency group lock

### DIFF
--- a/.github/workflows/manual-compare-versions-benchmark.yaml
+++ b/.github/workflows/manual-compare-versions-benchmark.yaml
@@ -28,12 +28,6 @@ on:
             description: "Enable all feature flags (false by default), version 2"
             default: false
 
-# Restrict to only running this workflow one at a time.
-# Any new runs will be queued until the previous run is complete.
-# Any existing pending runs will be cancelled and replaced with current run.
-#concurrency:
-#  group: continuous-benchmark
-
 jobs:
   prepareImage1:
     name: Prepare image ${{ inputs.qdrant_version_1 }}


### PR DESCRIPTION
Remove "concurrency group" configuration from workflow level, only keep it on a job's level. This helps to avoid a deadlock when GH can not determine which should cancel which.