### PR TITLE
Standardize default configs and add debug configs

### DIFF
--- a/experiments/configurations/elasticsearch-single-node.json
+++ b/experiments/configurations/elasticsearch-single-node.json
@@ -5,12 +5,24 @@
     "connection_params": {
       "request_timeout": 10000
     },
-    "collection_params": { "index_options": { "m": 16, "ef_construction": 100 } },
+    "collection_params": { "index_options": { "m": 16, "ef_construction": 128 } },
     "search_params": [
       { "parallel": 1, "config": { "num_candidates": 128 } }, { "parallel": 1, "config": { "num_candidates": 256 } }, { "parallel": 1, "config": { "num_candidates": 512 } },
       { "parallel": 100, "config": { "num_candidates": 128 } }, { "parallel": 100, "config": { "num_candidates": 256 } }, { "parallel": 100, "config": { "num_candidates": 512 } }
     ],
     "upload_params": { "parallel": 16 }
+  },
+  {
+    "name": "elasticsearch-debug",
+    "engine": "elasticsearch",
+    "connection_params": {
+      "request_timeout": 10000
+    },
+    "collection_params": { "index_options": { "m": 16, "ef_construction": 128 } },
+    "search_params": [
+      { "parallel": 1, "config": { "num_candidates": 128 } }, { "parallel": 1, "config": { "num_candidates": 256 } }, { "parallel": 1, "config": { "num_candidates": 512 } }
+    ],
+    "upload_params": { "parallel": 1 }
   },
   {
     "name": "elasticsearch-m-16-ef-128",

--- a/experiments/configurations/milvus-single-node.json
+++ b/experiments/configurations/milvus-single-node.json
@@ -8,7 +8,17 @@
       { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } },
       { "parallel": 100, "config": { "ef": 128 } }, { "parallel": 100, "config": { "ef": 256 } }, { "parallel": 100, "config": { "ef": 512 } }
     ],
-    "upload_params": { "parallel": 16, "index_params": { "efConstruction": 100, "M": 16 } }
+    "upload_params": { "parallel": 16, "index_params": { "efConstruction": 128, "M": 16 } }
+  },
+  {
+    "name": "milvus-debug",
+    "engine": "milvus",
+    "connection_params": {},
+    "collection_params": {},
+    "search_params": [
+      { "parallel": 1, "config": { "ef": 128 } }, { "parallel": 1, "config": { "ef": 256 } }, { "parallel": 1, "config": { "ef": 512 } }
+    ],
+    "upload_params": { "parallel": 1, "index_params": { "efConstruction": 128, "M": 16 } }
   },
   {
     "name": "milvus-m-16-ef-128",

--- a/experiments/configurations/opensearch-single-node.json
+++ b/experiments/configurations/opensearch-single-node.json
@@ -5,12 +5,24 @@
     "connection_params": {
       "request_timeout": 10000
     },
-    "collection_params": { "method": { "parameters": { "m": 16, "ef_construction": 100 } } },
-"search_params": [
+    "collection_params": { "method": { "parameters": { "m": 16, "ef_construction": 128 } } },
+    "search_params": [
       { "parallel": 1, "config": { "knn.algo_param.ef_search": 128 } }, { "parallel": 1, "config": { "knn.algo_param.ef_search": 256 } }, { "parallel": 1, "config": { "knn.algo_param.ef_search": 512 } },
       { "parallel": 100, "config": { "knn.algo_param.ef_search": 128 } }, { "parallel": 100, "config": { "knn.algo_param.ef_search": 256 } }, { "parallel": 100, "config": { "knn.algo_param.ef_search": 512 } }
     ],
     "upload_params": { "parallel": 16 }
+  },
+  {
+    "name": "opensearch-debug",
+    "engine": "opensearch",
+    "connection_params": {
+      "request_timeout": 10000
+    },
+    "collection_params": { "method": { "parameters": { "m": 16, "ef_construction": 128 } } },
+    "search_params": [
+      { "parallel": 1, "config": { "knn.algo_param.ef_search": 128 } }, { "parallel": 1, "config": { "knn.algo_param.ef_search": 256 } }, { "parallel": 1, "config": { "knn.algo_param.ef_search": 512 } }
+    ],
+    "upload_params": { "parallel": 1 }
   },
   {
     "name": "opensearch-m-16-ef-128",

--- a/experiments/configurations/pgvector-single-node.json
+++ b/experiments/configurations/pgvector-single-node.json
@@ -10,6 +10,16 @@
         "upload_params": { "parallel": 16, "batch_size": 1024, "hnsw_config": { "m": 16, "ef_construct": 128 } }
     },
     {
+        "name": "pgvector-debug",
+        "engine": "pgvector",
+        "connection_params": {},
+        "collection_params": {},
+        "search_params": [
+          { "parallel": 1, "config": { "hnsw_ef": 128 } }
+        ],
+        "upload_params": { "parallel": 1, "batch_size": 1024, "hnsw_config": { "m": 16, "ef_construct": 128 } }
+    },
+    {
       "name": "pgvector-parallel",
       "engine": "pgvector",
       "connection_params": {},

--- a/experiments/configurations/qdrant-native-single-node.json
+++ b/experiments/configurations/qdrant-native-single-node.json
@@ -4,12 +4,26 @@
     "engine": "qdrant_native",
     "connection_params": { "timeout": 30 },
     "collection_params": {
-      "optimizers_config": { "memmap_threshold": 10000000 }
+      "optimizers_config": { "memmap_threshold": 10000000 },
+      "hnsw_config": { "m": 16, "ef_construct": 128 }
     },
     "search_params": [
       { "parallel": 8, "config": { "hnsw_ef": 128 } }
     ],
     "upload_params": { "parallel": 16, "batch_size": 1024 }
+  },
+  {
+    "name": "qdrant-native-debug",
+    "engine": "qdrant_native",
+    "connection_params": { "timeout": 30 },
+    "collection_params": {
+      "optimizers_config": { "memmap_threshold": 10000000 },
+      "hnsw_config": { "m": 16, "ef_construct": 128 }
+    },
+    "search_params": [
+      { "parallel": 1, "config": { "hnsw_ef": 128 } }
+    ],
+    "upload_params": { "parallel": 1, "batch_size": 1024 }
   },
   {
     "name": "qdrant-native-continuous-benchmark",

--- a/experiments/configurations/qdrant-single-node.json
+++ b/experiments/configurations/qdrant-single-node.json
@@ -4,12 +4,26 @@
     "engine": "qdrant",
     "connection_params": { "timeout": 30 },
     "collection_params": {
-      "optimizers_config": { "memmap_threshold": 10000000 }
+      "optimizers_config": { "memmap_threshold": 10000000 },
+      "hnsw_config": { "m": 16, "ef_construct": 128 }
     },
     "search_params": [
       { "parallel": 8, "config": { "hnsw_ef": 128 } }
     ],
     "upload_params": { "parallel": 16, "batch_size": 1024 }
+  },
+  {
+    "name": "qdrant-debug",
+    "engine": "qdrant",
+    "connection_params": { "timeout": 30 },
+    "collection_params": {
+      "optimizers_config": { "memmap_threshold": 10000000 },
+      "hnsw_config": { "m": 16, "ef_construct": 128 }
+    },
+    "search_params": [
+      { "parallel": 1, "config": { "hnsw_ef": 128 } }
+    ],
+    "upload_params": { "parallel": 1, "batch_size": 1024 }
   },
   {
     "name": "qdrant-continuous-benchmark",

--- a/experiments/configurations/redis-single-node.json
+++ b/experiments/configurations/redis-single-node.json
@@ -4,12 +4,25 @@
     "engine": "redis",
     "connection_params": {},
     "collection_params": {
+      "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 }
     },
     "search_params": [
       { "parallel": 1, "config": { "EF": 64 } }, { "parallel": 1, "config": { "EF": 128 } }, { "parallel": 1, "config": { "EF": 256 } }, { "parallel": 1, "config": { "EF": 512 } },
       { "parallel": 100, "config": { "EF": 64 } }, { "parallel": 100, "config": { "EF": 128 } }, { "parallel": 100, "config": { "EF": 256 } }, { "parallel": 100, "config": { "EF": 512 } }
     ],
     "upload_params": { "parallel": 16, "batch_size": 1024 }
+  },
+  {
+    "name": "redis-debug",
+    "engine": "redis",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 }
+    },
+    "search_params": [
+      { "parallel": 1, "config": { "EF": 64 } }, { "parallel": 1, "config": { "EF": 128 } }, { "parallel": 1, "config": { "EF": 256 } }, { "parallel": 1, "config": { "EF": 512 } }
+    ],
+    "upload_params": { "parallel": 1, "batch_size": 1024 }
   },
   {
     "name": "redis-m-16-ef-128",

--- a/experiments/configurations/weaviate-single-node.json
+++ b/experiments/configurations/weaviate-single-node.json
@@ -5,11 +5,23 @@
     "connection_params": {
       "timeout_config": 1000
     },
-    "collection_params": { "vectorIndexConfig": { "efConstruction": 256, "maxConnections": 16 } },
+    "collection_params": { "vectorIndexConfig": { "efConstruction": 128, "maxConnections": 16 } },
     "search_params": [
       { "parallel": 8, "config": { "ef": 128 } }
     ],
     "upload_params": { "batch_size": 1024, "parallel": 8 }
+  },
+  {
+    "name": "weaviate-debug",
+    "engine": "weaviate",
+    "connection_params": {
+      "timeout_config": 1000
+    },
+    "collection_params": { "vectorIndexConfig": { "efConstruction": 128, "maxConnections": 16 } },
+    "search_params": [
+      { "parallel": 1, "config": { "ef": 128 } }
+    ],
+    "upload_params": { "batch_size": 1024, "parallel": 1 }
   },
   {
     "name": "weaviate-m-16-ef-128",


### PR DESCRIPTION
Closes #137

- All *-default configs now use m=16, ef_construction=128
- Added *-debug config for each engine with parallel=1 (upload + search)
- Specialty variants (on-disk, rps, quantization) left unchanged