### PR TITLE
Fix qdrant image version

### DIFF
--- a/engine/servers/qdrant-billion-scale/docker-compose.yaml
+++ b/engine/servers/qdrant-billion-scale/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   qdrant_bench:
-    image: qdrant/qdrant:${QDRANT_VERSION:-v1.11.0}
+    image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.0}
     ports:
       - "6333:6333"
       - "6334:6334"

--- a/engine/servers/qdrant-cluster-mode/docker-compose.yaml
+++ b/engine/servers/qdrant-cluster-mode/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   qdrant-node-0:
-    image: qdrant/qdrant:${QDRANT_VERSION:-v1.11.0}
+    image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.0}
     environment:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
@@ -18,7 +18,7 @@ services:
 
 
   qdrant-node-1:
-    image: qdrant/qdrant:${QDRANT_VERSION:-v1.11.0}
+    image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.0}
     environment:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true
@@ -36,7 +36,7 @@ services:
 
 
   qdrant-node-2:
-    image: qdrant/qdrant:${QDRANT_VERSION:-v1.11.0}
+    image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.0}
     environment:
       - QDRANT__SERVICE__GRPC_PORT=6334
       - QDRANT__CLUSTER__ENABLED=true

--- a/engine/servers/qdrant-limit-ram/docker-compose.yaml
+++ b/engine/servers/qdrant-limit-ram/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   qdrant_bench:
-    image: qdrant/qdrant:${QDRANT_VERSION:-v1.11.0}
+    image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.0}
     ports:
       - "6333:6333"
       - "6334:6334"

--- a/engine/servers/qdrant-single-node/docker-compose-limit-cpu.yaml.yml
+++ b/engine/servers/qdrant-single-node/docker-compose-limit-cpu.yaml.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   qdrant_bench:
-    image: qdrant/qdrant:${QDRANT_VERSION:-v1.11.0}
+    image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.0}
     network_mode: host
     logging:
       driver: "json-file"

--- a/engine/servers/qdrant-single-node/docker-compose.yaml
+++ b/engine/servers/qdrant-single-node/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   qdrant_bench:
-    image: ${CONTAINER_REGISTRY:-docker.io}/qdrant/qdrant:${QDRANT_VERSION:-v1.11.0}
+    image: ${CONTAINER_REGISTRY:-docker.io}/qdrant/qdrant:${QDRANT_VERSION:-v1.16.0}
     ports:
       - "6333:6333"
       - "6334:6334"


### PR DESCRIPTION
Due to a version incompatibility between the Qdrant image and its Python client library, the data was not being loaded into Qdrant during benchmarking. As a result, the benchmark was running on an empty collection with no data.

Updating the image version to 1.16.0 resolved the issue.

Video: https://www.youtube.com/watch?v=n0v_VCuTn3o 

UserWarning: Qdrant client version 1.16.3.dev0 is incompatible with server version 1.11.0. Major versions should match and minor version difference must not exceed 1. Set check_compatibility=False to skip version check.