### PR TITLE
fix elasticsearch and opensearch parsers to omit null bool clauses

### DIFF
--- a/engine/clients/elasticsearch/parser.py
+++ b/engine/clients/elasticsearch/parser.py
@@ -7,12 +7,14 @@ class ElasticConditionParser(BaseConditionParser):
     def build_condition(
         self, and_subfilters: Optional[List[Any]], or_subfilters: Optional[List[Any]]
     ) -> Optional[Any]:
-        return {
-            "bool": {
-                "must": and_subfilters,
-                "should": or_subfilters,
-            }
-        }
+        bool_clause = {}
+        if and_subfilters:
+            bool_clause["must"] = and_subfilters
+        if or_subfilters:
+            bool_clause["should"] = or_subfilters
+        if not bool_clause:
+            return None
+        return {"bool": bool_clause}
 
     def build_exact_match_filter(self, field_name: str, value: FieldValue) -> Any:
         return {"match": {field_name: value}}

--- a/engine/clients/opensearch/parser.py
+++ b/engine/clients/opensearch/parser.py
@@ -7,12 +7,14 @@ class OpenSearchConditionParser(BaseConditionParser):
     def build_condition(
         self, and_subfilters: Optional[List[Any]], or_subfilters: Optional[List[Any]]
     ) -> Optional[Any]:
-        return {
-            "bool": {
-                "must": and_subfilters,
-                "should": or_subfilters,
-            }
-        }
+        bool_clause = {}
+        if and_subfilters:
+            bool_clause["must"] = and_subfilters
+        if or_subfilters:
+            bool_clause["should"] = or_subfilters
+        if not bool_clause:
+            return None
+        return {"bool": bool_clause}
 
     def build_exact_match_filter(self, field_name: str, value: FieldValue) -> Any:
         return {"match": {field_name: value}}


### PR DESCRIPTION
## description 
- elasticsearch and opensearch `build_condition` now omits empty must/should keys and returns None when no clauses exist.
- unblocks filtered benchmarks against both engines and aligns their parser shape with qdrant_native and weaviate