### PR TITLE
fix: unmask worker exceptions that fail to pickle across multiprocessing

### DIFF
--- a/engine/base_client/search.py
+++ b/engine/base_client/search.py
@@ -7,6 +7,7 @@ import numpy as np
 import tqdm
 
 from dataset_reader.base_reader import Query
+from engine.base_client.utils import picklable_errors
 
 DEFAULT_TOP = 10
 
@@ -34,6 +35,7 @@ class BaseSearcher:
         raise NotImplementedError()
 
     @classmethod
+    @picklable_errors
     def _search_one(cls, query: Query, top: Optional[int] = None):
         if top is None:
             top = (

--- a/engine/base_client/upload.py
+++ b/engine/base_client/upload.py
@@ -5,7 +5,7 @@ from typing import Iterable, List
 import tqdm
 
 from dataset_reader.base_reader import Record
-from engine.base_client.utils import iter_batches
+from engine.base_client.utils import iter_batches, picklable_errors
 
 
 class BaseUploader:
@@ -84,6 +84,7 @@ class BaseUploader:
         }
 
     @classmethod
+    @picklable_errors
     def _upload_batch(cls, batch: List[Record]) -> float:
         start = time.perf_counter()
         cls.upload_batch(batch)

--- a/engine/base_client/utils.py
+++ b/engine/base_client/utils.py
@@ -1,4 +1,8 @@
-from typing import Iterable, List
+import functools
+import io
+import traceback
+from multiprocessing.reduction import ForkingPickler
+from typing import Callable, Iterable, List
 
 from dataset_reader.base_reader import Record
 
@@ -14,3 +18,39 @@ def iter_batches(records: Iterable[Record], n: int) -> Iterable[List[Record]]:
             batch = []
     if len(batch) > 0:
         yield batch
+
+
+class WorkerError(Exception):
+    """Picklable stand-in for an exception raised inside a multiprocessing worker.
+
+    Some client libraries raise exceptions that cannot be pickled (e.g. grpc
+    errors hold a ``threading.RLock``). When such an exception escapes a pool
+    worker, multiprocessing fails to send it back to the parent and reports an
+    opaque ``MaybeEncodingError`` instead, hiding the actual failure. Re-raising
+    the original traceback as this class keeps the diagnostics intact.
+    """
+
+
+def reraise_picklable(exc: BaseException) -> "WorkerError":
+    """Wrap `exc` in a picklable error carrying its formatted traceback."""
+    formatted = "".join(
+        traceback.format_exception(type(exc), exc, exc.__traceback__)
+    ).rstrip()
+    return WorkerError(f"{type(exc).__module__}.{type(exc).__qualname__}\n{formatted}")
+
+
+def picklable_errors(func: Callable) -> Callable:
+    """Ensure exceptions raised by `func` can cross a multiprocessing boundary."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:
+            try:
+                ForkingPickler(io.BytesIO()).dump(exc)
+            except Exception:
+                raise reraise_picklable(exc) from None
+            raise
+
+    return wrapper


### PR DESCRIPTION
When  a pool worker raises an exception that can't be pickled (e.g. a raw
  `grpc.RpcError`, which holds an `RLock`)multiprocessing loses it and reports
  an opaque `MaybeEncodingError` instead. Add a decorator that pickle-tests the exception. Diagnostic only.

Example run: https://github.com/qdrant/vector-db-benchmark/actions/runs/32110869861