### PR TITLE
fix: bound apt-get update

### DIFF
--- a/tools/setup_ci.sh
+++ b/tools/setup_ci.sh
@@ -2,14 +2,19 @@
 
 # Set up dependencies
 
-sudo apt update
-sudo apt install -y jq
+set -euo pipefail
+
+# apt can wedge indefinitely on a dpkg lock or a stalled mirror.
+apt_get() { sudo timeout 300 apt-get "$@"; }
+
+apt_get update || echo "apt-get update failed, continuing with the cached package list" >&2
+apt_get install -y jq
 
 # Download and install hcloud
 
 HCVERSION=v1.36.0
 
-wget https://github.com/hetznercloud/cli/releases/download/${HCVERSION}/hcloud-linux-amd64.tar.gz
+wget --timeout=30 --tries=3 https://github.com/hetznercloud/cli/releases/download/${HCVERSION}/hcloud-linux-amd64.tar.gz
 
 tar xzf hcloud-linux-amd64.tar.gz
 


### PR DESCRIPTION
Bound the `apt-get update`, 'cause it sometimes stalls during execution (nightly runs).

Example run: https://github.com/qdrant/vector-db-benchmark/actions/runs/32115998002