### PR TITLE
ci(elasticsearch): bump server images to 9.5.1

### DIFF
--- a/engine/servers/elasticsearch-single-node-ci/docker-compose.yaml
+++ b/engine/servers/elasticsearch-single-node-ci/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.5.1
     environment:
       ELASTIC_PASSWORD: "passwd"
       KIBANA_PASSWORD: "passwd"

--- a/engine/servers/elasticsearch-single-node/docker-compose.yaml
+++ b/engine/servers/elasticsearch-single-node/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.5.1
     environment:
       ELASTIC_PASSWORD: "passwd"
       KIBANA_PASSWORD: "passwd"


### PR DESCRIPTION
Related to https://github.com/qdrant/vector-db-benchmark/pull/315