### PR TITLE
chore(weaviate): bump server image to 1.38.10

### DIFF
--- a/engine/servers/weaviate-single-node/docker-compose.yaml
+++ b/engine/servers/weaviate-single-node/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - '8090'
     - --scheme
     - http
-    image: cr.weaviate.io/semitechnologies/weaviate:1.25.1
+    image: cr.weaviate.io/semitechnologies/weaviate:1.38.10
     ports:
       - "8090:8090"
       - "50051:50051"


### PR DESCRIPTION
Related to https://github.com/qdrant/vector-db-benchmark/pull/337